### PR TITLE
Fixed typo in SQLite usage example

### DIFF
--- a/src/content/docs/std/SQLite/usage.mdx
+++ b/src/content/docs/std/SQLite/usage.mdx
@@ -32,7 +32,7 @@ sqlite.execute(`create table if not exists kv(
 ```ts
 import { sqlite } from "https://esm.town/v/std/sqlite";
 
-cosnsole.log(await sqlite.execute(`select key, value from kv`));
+console.log(await sqlite.execute(`select key, value from kv`));
 ```
 
 ## Insert data


### PR DESCRIPTION
Fixed a typo (`cosnsole.log`) in the SQLite usage docs