### PR TITLE
Implement "Open In Val Town" button for selected code blocks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightLinksValidator from "starlight-links-validator";
+import { valTownOpenButton } from "./plugins/val-town-open-button.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -116,6 +117,9 @@ export default defineConfig({
           },
         },
       ],
+      expressiveCode: {
+        plugins: [valTownOpenButton()],
+      },
     }),
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@astrojs/starlight": "^0.14.0",
         "@fontsource/ibm-plex-sans": "^5.0.17",
         "astro": "^3.6.4",
+        "hast-util-select": "^6.0.2",
+        "hastscript": "^8.0.0",
         "sharp": "^0.33.0",
         "starlight-links-validator": "^0.4.2",
         "typescript": "^5.3.2"
@@ -193,6 +195,86 @@
       },
       "peerDependencies": {
         "astro": "^3.2.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
+    },
+    "node_modules/@astrojs/starlight/node_modules/hast-util-has-property": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.1.tgz",
+      "integrity": "sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/hast-util-select": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-5.0.5.tgz",
+      "integrity": "sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-to-string": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -926,6 +1008,34 @@
         "postcss-nested": "^6.0.1"
       }
     },
+    "node_modules/@expressive-code/core/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@expressive-code/core/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/@expressive-code/plugin-frames": {
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.29.2.tgz",
@@ -933,6 +1043,34 @@
       "dependencies": {
         "@expressive-code/core": "^0.29.2",
         "hastscript": "^7.2.0"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@expressive-code/plugin-shiki": {
@@ -952,6 +1090,34 @@
         "@expressive-code/core": "^0.29.2",
         "hastscript": "^7.2.0",
         "unist-util-visit-parents": "^5.1.3"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@fontsource/ibm-plex-sans": {
@@ -2578,9 +2744,19 @@
       }
     },
     "node_modules/css-selector-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
-      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.0.2.tgz",
+      "integrity": "sha512-eA5pvYwgtffuxQlDk0gJRApDUKgfwlsQBMAH6uawKuuilTLfxKIOtzyV63Y3IC0LWnDCeTJ/I1qYmlfYvvMzDg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -3217,34 +3393,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-from-html/node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html/node_modules/hastscript": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
-      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-from-html/node_modules/parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -3326,16 +3474,7 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-has-property": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.1.tgz",
-      "integrity": "sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
+    "node_modules/hast-util-from-parse5/node_modules/hast-util-parse-selector": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
       "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
@@ -3345,6 +3484,62 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/hast-util-raw": {
@@ -3370,25 +3565,90 @@
       }
     },
     "node_modules/hast-util-select": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-5.0.5.tgz",
-      "integrity": "sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.2.tgz",
+      "integrity": "sha512-hT/SD/d/Meu+iobvgkffo1QecV8WeKWxwsNMzcTJsKw1cKTQKSR/7ArJeURLNJF9HDjp9nVoORyNNJxrvBye8Q==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/unist": "^2.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
         "bcp-47-match": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
-        "css-selector-parser": "^1.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
         "direction": "^2.0.0",
-        "hast-util-has-property": "^2.0.0",
-        "hast-util-to-string": "^2.0.0",
-        "hast-util-whitespace": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
         "not": "^0.1.0",
         "nth-check": "^2.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0",
-        "unist-util-visit": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/hast-util-select/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3461,15 +3721,23 @@
       }
     },
     "node_modules/hast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.0.tgz",
+      "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
       "dependencies": {
-        "@types/hast": "^2.0.0"
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/hast-util-whitespace": {
@@ -3482,19 +3750,27 @@
       }
     },
     "node_modules/hastscript": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
-      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
+        "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^3.0.0",
+        "hast-util-parse-selector": "^4.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/html-escaper": {
@@ -6439,18 +6715,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/shikiji/node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/shikiji/node_modules/hast-util-raw": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
@@ -6522,22 +6786,6 @@
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/shikiji/node_modules/hastscript": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
-      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6907,14 +7155,6 @@
         "astro": ">=3.0.0"
       }
     },
-    "node_modules/starlight-links-validator/node_modules/@types/hast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
-      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/starlight-links-validator/node_modules/@types/mdast": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
@@ -6927,18 +7167,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
       "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
-    },
-    "node_modules/starlight-links-validator/node_modules/hast-util-has-property": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
-      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
     },
     "node_modules/starlight-links-validator/node_modules/mdast-util-to-string": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "astro": "^3.6.4",
     "sharp": "^0.33.0",
     "starlight-links-validator": "^0.4.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "hast-util-select": "^6.0.2",
+    "hastscript": "^8.0.0"
   }
 }

--- a/plugins/val-town-open-button.mjs
+++ b/plugins/val-town-open-button.mjs
@@ -41,7 +41,7 @@ export function valTownOpenButton() {
         const url = `https://www.val.town/embed/new?code=${encodedCode}`;
 
         // Display large button if there is a title
-        let caption = select(".has-title figcaption", renderData.blockAst);
+        const caption = select(".has-title figcaption", renderData.blockAst);
 
         if (caption) {
           caption.children.push(
@@ -59,9 +59,9 @@ export function valTownOpenButton() {
         }
 
         // Display a mini button next to the copy button
-        const miniButton = select("div.copy", renderData.blockAst);
-        if (miniButton) {
-          miniButton.children.push(
+        const copyButton = select("div.copy", renderData.blockAst);
+        if (copyButton) {
+          copyButton.children.push(
             h(
               "a",
               {

--- a/plugins/val-town-open-button.mjs
+++ b/plugins/val-town-open-button.mjs
@@ -38,7 +38,7 @@ export function valTownOpenButton() {
           /%20/g,
           "+"
         );
-        const url = `https://www.val.town/embed/new?code=${encodedCode}`;
+        const url = `https://www.val.town/new?code=${encodedCode}`;
 
         // Display large button if there is a title
         const caption = select(".has-title figcaption", renderData.blockAst);

--- a/plugins/val-town-open-button.mjs
+++ b/plugins/val-town-open-button.mjs
@@ -1,0 +1,84 @@
+import { h } from "hastscript";
+import { select } from "hast-util-select";
+
+export function valTownOpenButton() {
+  return {
+    name: "Val Town Open Button",
+    baseStyles: `
+      .frame.has-title:not(.is-terminal) figcaption {
+        justify-content: space-between;
+      }
+      .valtown-text-link {
+        align-self: center;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+      }
+      .valtown-text-link span:hover {
+        text-decoration: underline;
+        underline-offset: 0.2em;
+      }
+      .expressive-code .copy button.valtown::after {
+        -mask-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3C!-- Generator: Adobe Illustrator 26.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0) --%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 400 400' style='enable-background:new 0 0 400 400;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bclip-path:url(%23SVGID_00000160897194668637412090000012633273746754457781_);%7D%0A%3C/style%3E%3Cg%3E%3Cdefs%3E%3Crect id='SVGID_1_' y='56.1' width='400' height='287.7'/%3E%3C/defs%3E%3CclipPath id='SVGID_00000007401086114593429840000013539028411075735207_'%3E%3Cuse xlink:href='%23SVGID_1_' style='overflow:visible;'/%3E%3C/clipPath%3E%3Cg style='clip-path:url(%23SVGID_00000007401086114593429840000013539028411075735207_);'%3E%3Cpath d='M330.1,342.1c-14.4,0-26.1-4.5-35-13.4c-9-8.9-13.4-20.9-13.4-35.9V169.6h-28.9v-45.8h28.9V56.1h55.5v67.8H397v45.8h-59.9 v113.5c0,8.8,4.1,13.2,12.3,13.2h42.3v45.8H330.1z'/%3E%3Cpath d='M208.7,148.7l-92.3,152.9h-7.9V157.3c0-18.5-15-33.4-33.5-33.4H53v182.2c0,19.9,16.1,36,36,36h37.7 c20,0,38.5-10.7,48.5-28l110-190.3h-32.5C234.8,123.8,218,133.3,208.7,148.7z'/%3E%3Cpath d='M0,123.8h55.6v45.8H0V123.8z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+        -webkit-mask-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3C!-- Generator: Adobe Illustrator 26.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0) --%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 400 400' style='enable-background:new 0 0 400 400;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bclip-path:url(%23SVGID_00000160897194668637412090000012633273746754457781_);%7D%0A%3C/style%3E%3Cg%3E%3Cdefs%3E%3Crect id='SVGID_1_' y='56.1' width='400' height='287.7'/%3E%3C/defs%3E%3CclipPath id='SVGID_00000007401086114593429840000013539028411075735207_'%3E%3Cuse xlink:href='%23SVGID_1_' style='overflow:visible;'/%3E%3C/clipPath%3E%3Cg style='clip-path:url(%23SVGID_00000007401086114593429840000013539028411075735207_);'%3E%3Cpath d='M330.1,342.1c-14.4,0-26.1-4.5-35-13.4c-9-8.9-13.4-20.9-13.4-35.9V169.6h-28.9v-45.8h28.9V56.1h55.5v67.8H397v45.8h-59.9 v113.5c0,8.8,4.1,13.2,12.3,13.2h42.3v45.8H330.1z'/%3E%3Cpath d='M208.7,148.7l-92.3,152.9h-7.9V157.3c0-18.5-15-33.4-33.5-33.4H53v182.2c0,19.9,16.1,36,36,36h37.7 c20,0,38.5-10.7,48.5-28l110-190.3h-32.5C234.8,123.8,218,133.3,208.7,148.7z'/%3E%3Cpath d='M0,123.8h55.6v45.8H0V123.8z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+        
+      }
+    `,
+    hooks: {
+      postprocessRenderedBlock: ({ codeBlock, renderData }) => {
+        // Only run on val-town compatible code blocks
+        if (!["js", "ts", "jsx", "tsx"].includes(codeBlock.language)) return;
+
+        // Only run on blocks marked with `val` meta
+        const meta = codeBlock.meta.trim();
+        if (meta !== "val") return;
+
+        // Generate the URL
+        const encodedCode = encodeURIComponent(codeBlock.code).replace(
+          /%20/g,
+          "+"
+        );
+        const url = `https://www.val.town/embed/new?code=${encodedCode}`;
+
+        // Display large button if there is a title
+        let caption = select(".has-title figcaption", renderData.blockAst);
+
+        if (caption) {
+          caption.children.push(
+            h(
+              "a",
+              {
+                href: url,
+                class: "valtown-text-link",
+                target: "_blank",
+                rel: "noopener",
+              },
+              [h("span", { class: "title" }, ["Open in Val Town"])]
+            )
+          );
+        }
+
+        // Display a mini button next to the copy button
+        const miniButton = select("div.copy", renderData.blockAst);
+        if (miniButton) {
+          miniButton.children.push(
+            h(
+              "a",
+              {
+                href: url,
+                target: "_blank",
+                rel: "noopener",
+              },
+              [
+                h("button", { title: "Open in Val Town", class: "valtown" }, [
+                  h("div"),
+                ]),
+              ]
+            )
+          );
+          return;
+        }
+      },
+    },
+  };
+}

--- a/src/content/docs/types/http/jsx.mdx
+++ b/src/content/docs/types/http/jsx.mdx
@@ -3,8 +3,6 @@ title: HTML & JSX
 description: You can use JSX syntax in Val Town to render HTML using React, Preact, Vue, Solid, etc.
 ---
 
-import Val from "@components/Val.astro";
-
 Val Town supports server-rendered JSX. This lets you use JSX syntax to construct
 your HTML string. It does not include any client-side JSX framework features,
 such a re-rendering on the client.
@@ -25,16 +23,56 @@ A good default is [Preact](https://github.com/preactjs/preact), which provides a
 nice `preact-render-to-string` module that lets you quickly turn that JSX object
 into a string that you can use for a response.
 
-<Val url="https://www.val.town/embed/stevekrouse/preactExample" />
+```ts val
+/** @jsxImportSource https://esm.sh/preact */
+import { render } from "npm:preact-render-to-string";
+
+export const preactExample = () =>
+  new Response(render(<div>Test {1 + 1}</div>), {
+    headers: {
+      "Content-Type": "text/html",
+    },
+  });
+```
 
 ### React
 
-<Val url="https://www.val.town/embed/stevekrouse/reactExample" />
+```ts val
+/** @jsxImportSource https://esm.sh/react */
+import { renderToString } from "npm:react-dom/server";
+
+export const reactExample = () =>
+  new Response(renderToString(<div>Test {1 + 1}</div>), {
+    headers: {
+      "Content-Type": "text/html",
+    },
+  });
+```
 
 ### Vue
 
-<Val url="https://www.val.town/embed/stevekrouse/vueExample" />
+```ts val
+/** @jsxImportSource https://esm.sh/vue */
+import { renderToString } from "npm:vue/server-renderer";
+
+export const vueExample = async () =>
+  new Response(await renderToString(<div>Test {1 + 1}</div>), {
+    headers: {
+      "Content-Type": "text/html",
+    },
+  });
+```
 
 ### Solid
 
-<Val url="https://www.val.town/embed/stevekrouse/solidExample" />
+```ts val
+/** @jsxImportSource https://esm.sh/solid-jsx */
+import { renderToString } from "npm:solid-js/web";
+
+export const solidExample = async () =>
+  new Response(await renderToString(() => <div>Test {1 + 1}</div>), {
+    headers: {
+      "Content-Type": "text/html",
+    },
+  });
+```

--- a/src/content/docs/types/scheduled.mdx
+++ b/src/content/docs/types/scheduled.mdx
@@ -5,8 +5,6 @@ sidebar:
 description: "Schedules let code on Val Town run every day, every hour, or whenever you’d like"
 ---
 
-import Val from "@components/Val.astro";
-
 You can schedule code to run repeatedly on Val Town. Want to check an RSS
 feed every hour, or send a reminder email every day? This is how to do it:
 just create a scheduled function and specify when it should run.
@@ -16,7 +14,7 @@ just create a scheduled function and specify when it should run.
 Scheduled functions should take an `Interval` object as a parameter. Besides
 that, they can do and return anything - the return value is ignored.
 
-```tsx
+```tsx val
 // interval-example.tsx
 export function intervalHandler(interval: Interval) {
   console.log("Interval ran!");
@@ -55,4 +53,15 @@ Scheduled Vals can optionally accept one argument, which includes some metadata
 about the interval. For example, you can get the most recent time the interval
 was run to filter out data that was already seen:
 
-<Val url="https://www.val.town/embed/neverstew.scheduleExampleTwo" />
+```ts val
+// schedule-example.ts
+export const scheduleExampleTwo = async (interval: Interval) => {
+  const { default: RssParser } = await import("npm:rss-parser");
+  const parser = new RssParser();
+  const feed = await parser.parseURL("http://feeds.bbci.co.uk/news/rss.xml");
+  const newItems = feed.items.filter(
+    (item) => new Date(item.pubDate) > interval.lastRunAt
+  );
+  return `${newItems.length} new items!`;
+};
+```


### PR DESCRIPTION
Hopefully solves #26

This PR introduces ability to mark code blocks so that they will display a "Open in Val Town" button. When the button is pressed it opens a new tab with the code ready in Val Town (`https://www.val.town/embed/new?code=...`).

You can see examples in `scheduled.mdx` and `jsx.mdx`.

## Requirements

A code block must:
- be one of the supported languages: `js`/`jsx`/`ts`/`tsx`
- have the `val` meta tag added to it

## Usage examples

Examples of such code blocks:
````md
```ts val
// Code block without a title
```

```js val
// example.js
// Code block with a title
```

```tsx title="Example" {2-3} val
// Has title
// and
// Has code highlighting
```
````

## Code block with a title

If the code block has a title, it will display a large button in the top bar. Currently there is no icon next to the big button as I'm not sure what the styling is supposed to be here. I tried to keep it as close to the Expressive Code frame as possible so that in case the theme is changed, it will still look good.
![image](https://github.com/val-town/val-town-docs/assets/5722272/91752cc5-23cd-4c93-8e51-7264993b5409)

## Code block without a title

If there is no title, it will display only a small button next to the copy button. Those show up when the user hovers over the code block. I couldn't force the top bar to show up if the code block has no title.
![image](https://github.com/val-town/val-town-docs/assets/5722272/49344f1a-115e-4cf9-ae63-697052ce45ef)