### PR TITLE
Rewrite std/fetch overview

### DIFF
--- a/src/content/docs/std/fetch.md
+++ b/src/content/docs/std/fetch.md
@@ -2,7 +2,7 @@
 title: Proxied fetch
 ---
 
-The Javascript Fetch API is directly available within a Val. However, the requests sent using this API are not proxied or retried. This is problematic for some use cases where particular IP addresses may be blocked. Additionally, network blips or unreliable web services may lead to failed Vals if not handled properly.
+The Javascript Fetch API is directly available within a Val. However, the requests sent using this API are not proxied or retried. This is problematic in some use cases where requests may be blocked by the receiving server for using particular IP addresses. Additionally, network blips or unreliable web services may lead to failed Vals if not handled properly.
 
 The Val Town standard library contains an alternative version, `std/fetch`, that wraps the Javascript Fetch API to provide additional functionality. The fetch function from `std/fetch` reroutes requests using a proxy vendor so that all requests obtain different IP addresses. It also automatically retries failed requests several times. Note that using `std/fetch` may be slightly slower than directly calling the Javascript Fetch API due to rerouted requests.
 

--- a/src/content/docs/std/fetch.md
+++ b/src/content/docs/std/fetch.md
@@ -2,11 +2,13 @@
 title: Proxied fetch
 ---
 
-Val Town offers a proxied version of the standard fetch method that uses proxies and retries for more reliability. This is useful for websites that block requests made from data centers or have unreliable uptime. However it is slower than the standard `fetch` method. `std/fetch` has the same API as the standard fetch method.
+The Javascript Fetch API is directly available within a Val. However, the requests sent using this API are not proxied or retried. This is problematic for some use cases where particular IP addresses may be blocked. Additionally, network blips or unreliable web services may lead to failed Vals if not handled properly.
+
+The Val Town standard library contains an alternative version, `std/fetch`, that wraps the Javascript Fetch API to provide additional functionality. The fetch function from `std/fetch` reroutes requests using a proxy vendor so that all requests obtain different IP addresses. It also automatically retries failed requests several times. Note that using `std/fetch` may be slightly slower than directly calling the Javascript Fetch API due to rerouted requests.
 
 ## Usage
 
-You can use `std/fetch` just like the standard `fetch` method.
+After importing `std/fetch`, the fetch method is used with the same signature as the Fetch API.
 
 ```ts val
 import { fetch } from "https://esm.town/v/std/fetch";

--- a/src/content/docs/std/fetch.md
+++ b/src/content/docs/std/fetch.md
@@ -8,7 +8,7 @@ The Val Town standard library contains an alternative version, `std/fetch`, that
 
 ## Usage
 
-After importing `std/fetch`, the fetch method is used with the same signature as the Fetch API.
+After importing `std/fetch`, the fetch method is used with the same signature as the Javascript Fetch API.
 
 ```ts val
 import { fetch } from "https://esm.town/v/std/fetch";


### PR DESCRIPTION
* clarify "standard fetch" vs std/fetch
The documentation for `std/fetch` uses the words "standard fetch", even though it's actually not referring to `std/fetch`. Someone new to Javascript may find this confusing and have difficulty following the docs. So, I wanted to make the distinction very clear in the wording.

* emphasize and punch-up the value provided by the out-of-the-box proxy functionality
