### PR TITLE
Update links-validator so that we catch relative links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,14 @@
       "name": "val-town-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/check": "^0.3.2",
+        "@astrojs/check": "^0.3.3",
         "@astrojs/starlight": "^0.15.0",
         "@fontsource/ibm-plex-sans": "^5.0.18",
-        "astro": "^4.0.4",
+        "astro": "^4.0.6",
         "hast-util-select": "^6.0.2",
         "hastscript": "^8.0.0",
-        "sharp": "^0.33.0",
-        "starlight-links-validator": "^0.4.2",
+        "sharp": "^0.33.1",
+        "starlight-links-validator": "^0.5.1",
         "typescript": "^5.3.3"
       }
     },
@@ -32,11 +32,11 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.3.2.tgz",
-      "integrity": "sha512-3w+FUauJpfbR0sHPM7GXcn97sKgw2E+BBpXWyPwQQjxOZFU8AozVE7BP4kyGMPI+qYI2tGqDBklHMlezyfSb2A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.3.3.tgz",
+      "integrity": "sha512-IpglE0PNWEXmRY0y67EYuLwiyMxRUuZuG1oP+tIgqeQEy45g1pBMIWpGnNXdoVRbChHDWMSFd2kLUtgzBUHnRQ==",
       "dependencies": {
-        "@astrojs/language-server": "^2.5.3",
+        "@astrojs/language-server": "^2.5.4",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.3.1",
         "kleur": "^4.1.5",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.3.2.tgz",
-      "integrity": "sha512-jkY7bCVxl27KeZsSxIZ+pqACe+g8VQUdTiSJRj/sXYdIaZlW3ZMq4qF2M17P/oDt3LBq0zLNwQr4Cb7fSpRGxQ=="
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.3.4.tgz",
+      "integrity": "sha512-33/YtWoBCE0cBUNy1kh78FCDXBoBANX87ShgATlAHECYbG2+buNTAgq4Xgz4t5NgnEHPN21GIBC2Mvvwisoutw=="
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.2.1",
@@ -60,9 +60,9 @@
       "integrity": "sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A=="
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.5.3.tgz",
-      "integrity": "sha512-AcSWu/u+qtFxVbqEXWZQb57xy0JCXHRv7uOcogxGT6STGDrMiCCfkoAZnDPf3Xi2qOhG/vWKKOQZktpZhzCAmQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.5.4.tgz",
+      "integrity": "sha512-diTs8AW5TvpO6LWEyuAMAC1ydH1tnVJmv2dRrcczklJZcfY9/eYLbGtKiC9rEQH3BwvFdnphroMUEprzCiqSMg==",
       "dependencies": {
         "@astrojs/compiler": "^2.2.2",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -1315,9 +1315,9 @@
       "integrity": "sha512-xdtDTt5Ifdjdx//R8aAskULQuNR34D81pYTaZtk3q3fE7Fh2UDGHKCvlAoChG9NajThoLN+8PCrT0/cy/Dt5jg=="
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.0.tgz",
-      "integrity": "sha512-070tEheekI1LJWTGPC9WlQEa5UoKTXzzlORBHMX4TbfUxMiL336YHR8vBEUNsjse0RJCX8dZ4ZXwT595aEF1ug==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.1.tgz",
+      "integrity": "sha512-esr2BZ1x0bo+wl7Gx2hjssYhjrhUsD88VQulI0FrG8/otRQUOxLWHMBd1Y1qo2Gfg2KUvXNpT0ASnV9BzJCexw==",
       "cpu": [
         "arm64"
       ],
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.0.tgz",
-      "integrity": "sha512-pu/nvn152F3qbPeUkr+4e9zVvEhD3jhwzF473veQfMPkOYo9aoWXSfdZH/E6F+nYC3qvFjbxbvdDbUtEbghLqw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.1.tgz",
+      "integrity": "sha512-YrnuB3bXuWdG+hJlXtq7C73lF8ampkhU3tMxg5Hh+E7ikxbUVOU9nlNtVTloDXz6pRHt2y2oKJq7DY/yt+UXYw==",
       "cpu": [
         "x64"
       ],
@@ -1533,9 +1533,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.0.tgz",
-      "integrity": "sha512-4horD3wMFd5a0ddbDY8/dXU9CaOgHjEHALAddXgafoR5oWq5s8X61PDgsSeh4Qupsdo6ycfPPSSNBrfVQnwwrg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.1.tgz",
+      "integrity": "sha512-Ii4X1vnzzI4j0+cucsrYA5ctrzU9ciXERfJR633S2r39CiD8npqH2GMj63uFZRCFt3E687IenAdbwIpQOJ5BNA==",
       "cpu": [
         "arm"
       ],
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.0.tgz",
-      "integrity": "sha512-dcomVSrtgF70SyOr8RCOCQ8XGVThXwe71A1d8MGA+mXEVRJ/J6/TrCbBEJh9ddcEIIsrnrkolaEvYSHqVhswQw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.1.tgz",
+      "integrity": "sha512-59B5GRO2d5N3tIfeGHAbJps7cLpuWEQv/8ySd9109ohQ3kzyCACENkFVAnGPX00HwPTQcaBNF7HQYEfZyZUFfw==",
       "cpu": [
         "arm64"
       ],
@@ -1583,9 +1583,9 @@
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.0.tgz",
-      "integrity": "sha512-TiVJbx38J2rNVfA309ffSOB+3/7wOsZYQEOlKqOUdWD/nqkjNGrX+YQGz7nzcf5oy2lC+d37+w183iNXRZNngQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.1.tgz",
+      "integrity": "sha512-tRGrb2pHnFUXpOAj84orYNxHADBDIr0J7rrjwQrTNMQMWA4zy3StKmMvwsI7u3dEZcgwuMMooIIGWEWOjnmG8A==",
       "cpu": [
         "s390x"
       ],
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.0.tgz",
-      "integrity": "sha512-PaZM4Zi7/Ek71WgTdvR+KzTZpBqrQOFcPe7/8ZoPRlTYYRe43k6TWsf4GVH6XKRLMYeSp8J89RfAhBrSP4itNA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.1.tgz",
+      "integrity": "sha512-4y8osC0cAc1TRpy02yn5omBeloZZwS62fPZ0WUAYQiLhSFSpWJfY/gMrzKzLcHB9ulUV6ExFiu2elMaixKDbeg==",
       "cpu": [
         "x64"
       ],
@@ -1633,9 +1633,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.0.tgz",
-      "integrity": "sha512-1QLbbN0zt+32eVrg7bb1lwtvEaZwlhEsY1OrijroMkwAqlHqFj6R33Y47s2XUv7P6Ie1PwCxK/uFnNqMnkd5kg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.1.tgz",
+      "integrity": "sha512-D3lV6clkqIKUizNS8K6pkuCKNGmWoKlBGh5p0sLO2jQERzbakhu4bVX1Gz+RS4vTZBprKlWaf+/Rdp3ni2jLfA==",
       "cpu": [
         "arm64"
       ],
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.0.tgz",
-      "integrity": "sha512-CecqgB/CnkvCWFhmfN9ZhPGMLXaEBXl4o7WtA6U3Ztrlh/s7FUKX4vNxpMSYLIrWuuzjiaYdfU3+Tdqh1xaHfw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.1.tgz",
+      "integrity": "sha512-LOGKNu5w8uu1evVqUAUKTix2sQu1XDRIYbsi5Q0c/SrXhvJ4QyOx+GaajxmOg5PZSsSnCYPSmhjHHsRBx06/wQ==",
       "cpu": [
         "x64"
       ],
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.0.tgz",
-      "integrity": "sha512-Hn4js32gUX9qkISlemZBUPuMs0k/xNJebUNl/L6djnU07B/HAA2KaxRVb3HvbU5fL242hLOcp0+tR+M8dvJUFw==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.1.tgz",
+      "integrity": "sha512-vWI/sA+0p+92DLkpAMb5T6I8dg4z2vzCUnp8yvxHlwBpzN8CIcO3xlSXrLltSvK6iMsVMNswAv+ub77rsf25lA==",
       "cpu": [
         "wasm32"
       ],
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.0.tgz",
-      "integrity": "sha512-5HfcsCZi3l5nPRF2q3bllMVMDXBqEWI3Q8KQONfzl0TferFE5lnsIG0A1YrntMAGqvkzdW6y1Ci1A2uTvxhfzg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.1.tgz",
+      "integrity": "sha512-/xhYkylsKL05R+NXGJc9xr2Tuw6WIVl2lubFJaFYfW4/MQ4J+dgjIo/T4qjNRizrqs/szF/lC9a5+updmY9jaQ==",
       "cpu": [
         "ia32"
       ],
@@ -1725,9 +1725,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.0.tgz",
-      "integrity": "sha512-i3DtP/2ce1yKFj4OzOnOYltOEL/+dp4dc4dJXJBv6god1AFTcmkaA99H/7SwOmkCOBQkbVvA3lCGm3/5nDtf9Q==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.1.tgz",
+      "integrity": "sha512-XaM69X0n6kTEsp9tVYYLhXdg7Qj32vYJlAKRutxUsm1UlgQNx6BOhHwZPwukCGXBU2+tH87ip2eV1I/E8MQnZg==",
       "cpu": [
         "x64"
       ],
@@ -2429,11 +2429,11 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.4.tgz",
-      "integrity": "sha512-KhwoF5//kFusczKN46ZG185uk9BQt1OH5949wsrFKs0z7Oo/o31XyxKyqIW8ZSL0fWU4XYKSdYlAo1RaPF9TtA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.6.tgz",
+      "integrity": "sha512-P7CfFqWKzkJozzF6IoOC6qoI2ONndV8P3ULhGDgMiXPL7xVkWI5haTBSpyrcjBx643tVXspIRsSV/v+Cx+CjGw==",
       "dependencies": {
-        "@astrojs/compiler": "^2.3.2",
+        "@astrojs/compiler": "^2.3.4",
         "@astrojs/internal-helpers": "0.2.1",
         "@astrojs/markdown-remark": "4.0.1",
         "@astrojs/telemetry": "3.0.4",
@@ -7485,9 +7485,9 @@
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
     },
     "node_modules/sharp": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.0.tgz",
-      "integrity": "sha512-99DZKudjm/Rmz+M0/26t4DKpXyywAOJaayGS9boEn7FvgtG0RYBi46uPE2c+obcJRtA3AZa0QwJot63gJQ1F0Q==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.1.tgz",
+      "integrity": "sha512-iAYUnOdTqqZDb3QjMneBKINTllCJDZ3em6WaWy7NPECM4aHncvqHRm0v0bN9nqJxMiwamv5KIdauJ6lUzKDpTQ==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -7502,8 +7502,8 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.0",
-        "@img/sharp-darwin-x64": "0.33.0",
+        "@img/sharp-darwin-arm64": "0.33.1",
+        "@img/sharp-darwin-x64": "0.33.1",
         "@img/sharp-libvips-darwin-arm64": "1.0.0",
         "@img/sharp-libvips-darwin-x64": "1.0.0",
         "@img/sharp-libvips-linux-arm": "1.0.0",
@@ -7512,15 +7512,15 @@
         "@img/sharp-libvips-linux-x64": "1.0.0",
         "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
         "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
-        "@img/sharp-linux-arm": "0.33.0",
-        "@img/sharp-linux-arm64": "0.33.0",
-        "@img/sharp-linux-s390x": "0.33.0",
-        "@img/sharp-linux-x64": "0.33.0",
-        "@img/sharp-linuxmusl-arm64": "0.33.0",
-        "@img/sharp-linuxmusl-x64": "0.33.0",
-        "@img/sharp-wasm32": "0.33.0",
-        "@img/sharp-win32-ia32": "0.33.0",
-        "@img/sharp-win32-x64": "0.33.0"
+        "@img/sharp-linux-arm": "0.33.1",
+        "@img/sharp-linux-arm64": "0.33.1",
+        "@img/sharp-linux-s390x": "0.33.1",
+        "@img/sharp-linux-x64": "0.33.1",
+        "@img/sharp-linuxmusl-arm64": "0.33.1",
+        "@img/sharp-linuxmusl-x64": "0.33.1",
+        "@img/sharp-wasm32": "0.33.1",
+        "@img/sharp-win32-ia32": "0.33.1",
+        "@img/sharp-win32-x64": "0.33.1"
       }
     },
     "node_modules/shebang-command": {
@@ -7684,9 +7684,9 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/starlight-links-validator": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.4.2.tgz",
-      "integrity": "sha512-zTI1Si2SSuJYBH1ZdIEhF5+l2fj0+W5eOjLD4oVoPCZrTvz4bfNxOrAAqmlo8R1Pf423KbSYKS5fxDGRpuJnIA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.5.1.tgz",
+      "integrity": "sha512-6iNl/bTTFN65T3fx1oMdspZltlYyonmrnno4dWjMzJuFHO79ZGKyzrtuMD59kiM9Y85eSy3MOpU1wuPoY28fMg==",
       "dependencies": {
         "github-slugger": "2.0.0",
         "hast-util-from-html": "2.0.1",
@@ -7699,8 +7699,8 @@
         "node": ">=18.14.1"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.9.0",
-        "astro": ">=3.0.0"
+        "@astrojs/starlight": ">=0.15.0",
+        "astro": ">=4.0.0"
       }
     },
     "node_modules/stdin-discarder": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/check": "^0.3.2",
+    "@astrojs/check": "^0.3.3",
     "@astrojs/starlight": "^0.15.0",
     "@fontsource/ibm-plex-sans": "^5.0.18",
-    "astro": "^4.0.4",
-    "sharp": "^0.33.0",
-    "starlight-links-validator": "^0.4.2",
+    "astro": "^4.0.6",
+    "sharp": "^0.33.1",
+    "starlight-links-validator": "^0.5.1",
     "typescript": "^5.3.3",
     "hast-util-select": "^6.0.2",
     "hastscript": "^8.0.0"


### PR DESCRIPTION
There's a useful new feature in the links validator - https://github.com/HiDeoo/starlight-links-validator/issues/21

Relative links aren't validated so they're often silently wrong. This will raise an error on a detected relative link.