### PR TITLE
Add hono JSX example

### DIFF
--- a/src/content/docs/types/http/jsx.mdx
+++ b/src/content/docs/types/http/jsx.mdx
@@ -76,3 +76,19 @@ export const solidExample = async () =>
     },
   });
 ```
+
+### Hono
+
+```ts val
+/** @jsxImportSource npm:hono@3/jsx */
+
+export const honoExample = () => {
+  const jsx = <div>Test {1 + 1}</div>;
+
+  return new Response(jsx.toString(), {
+    headers: {
+      "Content-Type": "text/html",
+    },
+  });
+};
+```


### PR DESCRIPTION
Added an example of Hono's [JSX support](https://hono.dev/guides/jsx) to the http/jsx section.

I opted for using the NPM package with a `jsxImportSource` directive instead of their suggested Deno import, in order to keep a similar style to the other examples.