### PR TITLE
Removed markup remnants

### DIFF
--- a/src/content/docs/std/SQLite/orms.mdx
+++ b/src/content/docs/std/SQLite/orms.mdx
@@ -32,5 +32,3 @@ only exists in a classic server environment.
 
 🚫 Sequelize isn't supported in Val Town because it relies on specific database
 drivers and is not extensible.
-
-:::


### PR DESCRIPTION
That `:::` looks strange on the page https://docs.val.town/std/sqlite/orms/

I'm pretty sure that this is just a bug. That `:::` was the closing for `:::note[Sequelize]`, but after commit https://github.com/val-town/val-town-docs/commit/469511e7ab883a9337e7343d59a743922ad011d9 there is no more `:::note[Sequelize]` (it was in file `src/content/docs/std/sqlite.mdx`, github by default does not expand diff for that file)