### PR TITLE
Last updated dates (v3)

### DIFF
--- a/src/content/docs/api/aliases.mdx
+++ b/src/content/docs/api/aliases.mdx
@@ -3,6 +3,7 @@ title: Aliases
 generated: 1701279907960
 description: |
   An API that helps you map from usernames and handles to identifiers.
+lastUpdated: 2023-12-22
 ---
 
 :::note

--- a/src/content/docs/api/authentication.mdx
+++ b/src/content/docs/api/authentication.mdx
@@ -3,6 +3,7 @@ title: Authentication
 description: |
   How to authenticate to Val Town using a Bearer token in HTTP headers
 generated: 1701279907965
+lastUpdated: 2023-12-22
 ---
 
 The Val Town APIs accept Bearer Token authentication for full access to your Val

--- a/src/content/docs/api/eval.mdx
+++ b/src/content/docs/api/eval.mdx
@@ -3,6 +3,7 @@ title: Eval
 description: |
   An API that lets you run arbitrary TypeScript and JavaScript via REST
 generated: 1701279907968
+lastUpdated: 2023-12-22
 ---
 
 The Eval API lets you run arbitrary JavaScript/TypeScript, with full access to

--- a/src/content/docs/api/my-resources.mdx
+++ b/src/content/docs/api/my-resources.mdx
@@ -1,8 +1,10 @@
 ---
 title: My resources
 generated: 1701279907977
-description: |
-  API shortcuts to get your own resources, like vals that you created or have run.
+description: >
+  API shortcuts to get your own resources, like vals that you created or have
+  run.
+lastUpdated: 2023-12-22
 ---
 
 When using the Val Town API, some of the most common functions operate on things

--- a/src/content/docs/api/overview.mdx
+++ b/src/content/docs/api/overview.mdx
@@ -3,6 +3,7 @@ title: Overview
 generated: 1701279907910
 sidebar:
   order: 1
+lastUpdated: 2023-12-15
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/api/run.mdx
+++ b/src/content/docs/api/run.mdx
@@ -3,6 +3,7 @@ title: Run
 generated: 1701279907981
 description: |
   An API that lets you run custom TypeScript functions via HTTP
+lastUpdated: 2023-12-22
 ---
 
 The Run API lets you run any Val as an API. Unauthenticated use will only have

--- a/src/content/docs/api/users.mdx
+++ b/src/content/docs/api/users.mdx
@@ -3,6 +3,7 @@ title: Users
 generated: 1701279907983
 description: |
   An API that lets you retrieve basic information about a user on Val Town
+lastUpdated: 2023-12-22
 ---
 
 ## GET `/v1/users/{user_id}`

--- a/src/content/docs/api/vals.mdx
+++ b/src/content/docs/api/vals.mdx
@@ -1,6 +1,7 @@
 ---
 title: Vals
 generated: 1701279907985
+lastUpdated: 2023-12-22
 ---
 
 The vals endpoints allow you to manipulate vals.

--- a/src/content/docs/contact-us/contact-us.md
+++ b/src/content/docs/contact-us/contact-us.md
@@ -3,6 +3,7 @@ title: Contact Us
 tableOfContents: false
 description: |
   The Val Town team is always available via email and Discord.
+lastUpdated: 2023-12-05
 ---
 
 - [hi@val.town](mailto:hi@val.town)

--- a/src/content/docs/contact-us/security.md
+++ b/src/content/docs/contact-us/security.md
@@ -1,8 +1,10 @@
 ---
 title: Security
 generated: 1701279907852
-description: |
-  Val Town takes security seriously: these are the details on how to contact us if you have any concerns.
+description: >
+  Val Town takes security seriously: these are the details on how to contact us
+  if you have any concerns.
+lastUpdated: 2023-12-04
 ---
 
 The security of our systems is our top priority. We appreciate investigative

--- a/src/content/docs/guides/creating-a-webhook.mdx
+++ b/src/content/docs/guides/creating-a-webhook.mdx
@@ -2,6 +2,7 @@
 title: Creating a webhook
 generated: 1701279907748
 description: Use Val Town to receive HTTP webhooks from services like Discord or Stripe
+lastUpdated: 2023-12-22
 ---
 
 A webhook is another name for a

--- a/src/content/docs/guides/embed.mdx
+++ b/src/content/docs/guides/embed.mdx
@@ -1,6 +1,7 @@
 ---
 title: Embedding Vals in other sites
 description: Any val can be embedded as an iframe on other sites
+lastUpdated: 2023-12-15
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/generate-pdfs.mdx
+++ b/src/content/docs/guides/generate-pdfs.mdx
@@ -1,8 +1,10 @@
 ---
 title: Generate PDFs
 generated: 1701279907759
-description: |
-  Using jsPDF, you can generate PDFs from scratch and download them from Val Town.
+description: >
+  Using jsPDF, you can generate PDFs from scratch and download them from Val
+  Town.
+lastUpdated: 2023-12-22
 ---
 
 You can generate PDFs using val functions by using an external library like [jsPDF](https://github.com/parallax/jsPDF).

--- a/src/content/docs/guides/push-notifications.mdx
+++ b/src/content/docs/guides/push-notifications.mdx
@@ -1,8 +1,10 @@
 ---
 title: Push notifications
 generated: 1701279907821
-description: |
-  Using the third-party service ntfy.sh, you can send push notifications to phones and computer with Val Town.
+description: >
+  Using the third-party service ntfy.sh, you can send push notifications to
+  phones and computer with Val Town.
+lastUpdated: 2023-12-08
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/qr-code.mdx
+++ b/src/content/docs/guides/qr-code.mdx
@@ -3,6 +3,7 @@ title: QR Code
 generated: 1701279907824
 description: |
   Val Town can be used as a way to generate QR Codes.
+lastUpdated: 2023-12-04
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/saving-data-from-a-web-page.mdx
+++ b/src/content/docs/guides/saving-data-from-a-web-page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Saving data from a web page
 generated: 1701279907847
+lastUpdated: 2023-12-15
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/weather.mdx
+++ b/src/content/docs/guides/weather.mdx
@@ -1,6 +1,7 @@
 ---
 title: Weather
 generated: 1701279907930
+lastUpdated: 2023-12-05
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/web-scraping.mdx
+++ b/src/content/docs/guides/web-scraping.mdx
@@ -1,6 +1,7 @@
 ---
 title: Web scraping
 generated: 1701279907934
+lastUpdated: 2023-12-22
 ---
 
 You can use vals to scrape websites.

--- a/src/content/docs/guides/website-uptime-tracker.mdx
+++ b/src/content/docs/guides/website-uptime-tracker.mdx
@@ -1,6 +1,7 @@
 ---
 title: Website Uptime Tracker
 generated: 1701279907938
+lastUpdated: 2023-12-02
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: Val Town Docs
-description: Create APIs, scheduled functions, email yourself, and persist data — all from the browser and instantly deployed.
+description: Create APIs, scheduled functions, email yourself, and persist data
+  — all from the browser and instantly deployed.
 tableOfContents: false
+lastUpdated: 2023-12-15
 ---
 
 Val Town is a social website to write and deploy JavaScript. Create APIs, scheduled functions, email yourself,

--- a/src/content/docs/integrations/Databases/neon-postgres.mdx
+++ b/src/content/docs/integrations/Databases/neon-postgres.mdx
@@ -1,8 +1,10 @@
 ---
 title: Neon Postgres
 generated: 1701279907805
-description: |
-  How to integrate with Neon, a hosted Postgres platform that does horizontal scaling and includes an SQL-over-HTTP API.
+description: >
+  How to integrate with Neon, a hosted Postgres platform that does horizontal
+  scaling and includes an SQL-over-HTTP API.
+lastUpdated: 2023-12-22
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/integrations/Databases/planetscale.mdx
+++ b/src/content/docs/integrations/Databases/planetscale.mdx
@@ -1,8 +1,10 @@
 ---
 title: PlanetScale
 generated: 1701279907815
-description: |
-  How to store data in PlanetScale, a hosted MySQL platform with the ability to scale beyond a single instance and evolve schemas.
+description: >
+  How to store data in PlanetScale, a hosted MySQL platform with the ability to
+  scale beyond a single instance and evolve schemas.
+lastUpdated: 2023-12-22
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/integrations/Databases/supabase.mdx
+++ b/src/content/docs/integrations/Databases/supabase.mdx
@@ -4,6 +4,7 @@ generated: 1701279907867
 description: |
   How to connect Val Town to Supabase, a hosted Postgres-as-a-platform
   that lets you make queries via HTTP.
+lastUpdated: 2023-12-22
 ---
 
 [Supabase](https://supabase.com/) provide a hosted Postgres database with 500MB

--- a/src/content/docs/integrations/Databases/upstash.mdx
+++ b/src/content/docs/integrations/Databases/upstash.mdx
@@ -3,6 +3,7 @@ title: Upstash
 generated: 1701279907898
 description: |
   Using Upstash, a hosting provider that provides free 1MB Redis instances.
+lastUpdated: 2023-12-22
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/integrations/Discord/bot.mdx
+++ b/src/content/docs/integrations/Discord/bot.mdx
@@ -3,6 +3,7 @@ title: Discord welcome bot
 generated: 1701279907737
 description: |
   Create a Discord bot that sends a DM to new users.
+lastUpdated: 2023-12-08
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/integrations/Discord/how-to-make-a-discord-bot-hosted-24-7-for-free-in-.mdx
+++ b/src/content/docs/integrations/Discord/how-to-make-a-discord-bot-hosted-24-7-for-free-in-.mdx
@@ -2,6 +2,7 @@
 title: Discord bot
 generated: 1701279907787
 description: How to make a Discord bot hosted 24/7 for free in 6 steps
+lastUpdated: 2023-12-22
 ---
 
 ![https://i.postimg.cc/bw5Xj8Rd/ping.gif](https://i.postimg.cc/bw5Xj8Rd/ping.gif)

--- a/src/content/docs/integrations/Discord/send-message.mdx
+++ b/src/content/docs/integrations/Discord/send-message.mdx
@@ -3,6 +3,7 @@ title: Send Discord message via webhook
 generated: 1701279907853
 description: |
   Shows you how to receive webhooks from Discord on Val Town.
+lastUpdated: 2023-12-22
 ---
 
 1. Create a Discord webhook

--- a/src/content/docs/integrations/GitHub/get-a-github-user.mdx
+++ b/src/content/docs/integrations/GitHub/get-a-github-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: Get a Github user
 generated: 1701279907762
+lastUpdated: 2023-12-22
 ---
 
 For example, we can get a user without passing an authentication token.

--- a/src/content/docs/integrations/GitHub/github-users-stars-pagination.mdx
+++ b/src/content/docs/integrations/GitHub/github-users-stars-pagination.mdx
@@ -1,6 +1,7 @@
 ---
 title: Github user's stars (pagination)
 generated: 1701279907766
+lastUpdated: 2023-12-22
 ---
 
 When there are many results, GitHub

--- a/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
+++ b/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
@@ -1,6 +1,7 @@
 ---
 title: Receiving a GitHub Webhook
 generated: 1701279907831
+lastUpdated: 2023-12-22
 ---
 
 GitHub supports sending webhooks for a

--- a/src/content/docs/integrations/Slack/bot.mdx
+++ b/src/content/docs/integrations/Slack/bot.mdx
@@ -2,6 +2,7 @@
 title: Slack bot
 generated: 1701279907711
 description: Create a Slack bot that replies to mentions
+lastUpdated: 2023-12-22
 ---
 
 You can build a Slack bot using vals.

--- a/src/content/docs/integrations/Slack/send-messages-to-slack.mdx
+++ b/src/content/docs/integrations/Slack/send-messages-to-slack.mdx
@@ -3,6 +3,7 @@ title: Send messages to Slack
 generated: 1701279907862
 description: |
   Create a bot that sends new messages into a Slack channel.
+lastUpdated: 2023-12-22
 ---
 
 You can send messages to Slack from vals.

--- a/src/content/docs/integrations/airtable.mdx
+++ b/src/content/docs/integrations/airtable.mdx
@@ -1,7 +1,9 @@
 ---
 title: Airtable
 generated: 1701279907727
-description: You can use Airtable with Val Town to store data or load edited data from other sources
+description: You can use Airtable with Val Town to store data or load edited
+  data from other sources
+lastUpdated: 2023-12-22
 ---
 
 Airtable is a spreadsheet-database hybrid. Note that because

--- a/src/content/docs/integrations/google-sheets.mdx
+++ b/src/content/docs/integrations/google-sheets.mdx
@@ -1,6 +1,7 @@
 ---
 title: Google Sheets
 description: Using the Google Sheets API, you can add rows to a spreadsheet with Val Town.
+lastUpdated: 2023-12-22
 ---
 
 You can send data to Google Sheets from a val. You can collect

--- a/src/content/docs/integrations/s3.mdx
+++ b/src/content/docs/integrations/s3.mdx
@@ -4,6 +4,7 @@ generated: 1701279907886
 description: |
   S3 is Amazon's very popular object storage system. You can upload & download
   objects on S3 using Val Town.
+lastUpdated: 2023-12-22
 ---
 
 You can upload and download from AWS S3 inside val functions.

--- a/src/content/docs/integrations/sqlite-wasm.mdx
+++ b/src/content/docs/integrations/sqlite-wasm.mdx
@@ -5,6 +5,7 @@ pagefind: false
 description: |
   Using Deno's ability to load WASM modules, you can actually run SQLite
   right in Val Town.
+lastUpdated: 2023-12-04
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/integrations/telegram.mdx
+++ b/src/content/docs/integrations/telegram.mdx
@@ -4,6 +4,7 @@ generated: 1701279907743
 description: |
   You can create a bot for Telegram, the popular messaging app, using Val Town,
   letting your vals receive and respond to messages.
+lastUpdated: 2023-12-22
 ---
 
 You can create Telegram bots using vals.

--- a/src/content/docs/reference/custom-domains.md
+++ b/src/content/docs/reference/custom-domains.md
@@ -2,9 +2,10 @@
 title: Custom domains
 description: Point your own domains to any HTTP val
 sidebar:
-    badge:
-        text: PRO
-        variant: note
+  badge:
+    text: PRO
+    variant: note
+lastUpdated: 2024-01-08
 ---
 
 :::note

--- a/src/content/docs/reference/environment-variables.md
+++ b/src/content/docs/reference/environment-variables.md
@@ -2,6 +2,7 @@
 title: Environment variables
 generated: 1701279907850
 description: Using environment variables to store secrets that vals can securely access
+lastUpdated: 2023-12-22
 ---
 
 The proper place to store secrets, keys, and API tokens is in

--- a/src/content/docs/reference/import.mdx
+++ b/src/content/docs/reference/import.mdx
@@ -1,6 +1,7 @@
 ---
 title: Importing
 description: Import code from vals, NPM, and URLs
+lastUpdated: 2024-01-05
 ---
 
 One of the best features of Val Town is the ability to import modules. There are thousands

--- a/src/content/docs/reference/permissions.mdx
+++ b/src/content/docs/reference/permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Permissions
 description: Vals can be private, unlisted, or public
+lastUpdated: 2023-12-22
 ---
 
 There are three privacy states for a Val:

--- a/src/content/docs/reference/runtime.mdx
+++ b/src/content/docs/reference/runtime.mdx
@@ -1,6 +1,7 @@
 ---
 title: Runtime
 description: Val Town uses the Deno runtime to run your code
+lastUpdated: 2023-12-05
 ---
 
 Val Town uses the Deno runtime.

--- a/src/content/docs/reference/shortcuts.mdx
+++ b/src/content/docs/reference/shortcuts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Keyboard shortcuts
 description: Keyboard shortcuts for Val Town
+lastUpdated: 2023-12-05
 ---
 
 - `ctrl/cmd-enter` to run a val

--- a/src/content/docs/reference/version-control.mdx
+++ b/src/content/docs/reference/version-control.mdx
@@ -1,6 +1,8 @@
 ---
 title: Version Control
-description: Every time you save a val it creates a new immutable version in the version history.
+description: Every time you save a val it creates a new immutable version in the
+  version history.
+lastUpdated: 2023-12-15
 ---
 
 Vals are immutable but you can publish new versions of vals. Versions start at

--- a/src/content/docs/std/SQLite/index.mdx
+++ b/src/content/docs/std/SQLite/index.mdx
@@ -1,8 +1,11 @@
 ---
 title: SQLite
-description: Val Town SQLite is a lightweight, standard database. Every Val Town account comes with its own private SQLite database that is accessible from any of your vals.
+description: Val Town SQLite is a lightweight, standard database. Every Val Town
+  account comes with its own private SQLite database that is accessible from any
+  of your vals.
 sidebar:
   order: 0
+lastUpdated: 2023-12-27
 ---
 
 SQLite is a lightweight, standard database. Every Val Town account comes with its own private SQLite database that is accessible from any of your vals via [`std/sqlite`](https://www.val.town/v/std/sqlite).

--- a/src/content/docs/std/SQLite/migrations.mdx
+++ b/src/content/docs/std/SQLite/migrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Migrations
+lastUpdated: 2023-12-22
 ---
 
 One way to run migrations in Val Town is to write a single val and keep

--- a/src/content/docs/std/SQLite/orms.mdx
+++ b/src/content/docs/std/SQLite/orms.mdx
@@ -1,5 +1,6 @@
 ---
 title: ORMs
+lastUpdated: 2024-01-05
 ---
 
 Writing SQL is really fast and it's great for small projects. As your projects

--- a/src/content/docs/std/SQLite/usage.mdx
+++ b/src/content/docs/std/SQLite/usage.mdx
@@ -3,6 +3,7 @@ title: Usage
 description: How to use Val Town SQLite, with examples.
 sidebar:
   order: 1
+lastUpdated: 2023-12-27
 ---
 
 Val Town [SQLite val](https://www.val.town/v/std/sqlite) has two methods: `execute` [↗](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#execute-a-single-statement) and `batch` [↗](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#batches-and-interactive-transactions). Below are examples of how to use them in Val Town.

--- a/src/content/docs/std/blob.mdx
+++ b/src/content/docs/std/blob.mdx
@@ -1,5 +1,6 @@
 ---
 title: Blob Storage
+lastUpdated: 2024-01-05
 ---
 
 Val Town now comes with blob storage built-in. It allows for storing any data: text, JSON, images. Access it via [`std/blob`](https://www.val.town/v/std/blob).

--- a/src/content/docs/std/email.md
+++ b/src/content/docs/std/email.md
@@ -1,5 +1,6 @@
 ---
 title: Email
+lastUpdated: 2024-01-05
 ---
 
 Send emails with [`std/email`](https://www.val.town/v/std/email). You can only send emails to yourself if you're on Val Town Free. If you're on Val Town Pro, you can email to anyone.

--- a/src/content/docs/std/fetch.md
+++ b/src/content/docs/std/fetch.md
@@ -1,5 +1,6 @@
 ---
 title: Proxied fetch
+lastUpdated: 2023-12-27
 ---
 
 The Javascript Fetch API is directly available within a Val. However, the requests sent using this API are not proxied or retried. This is problematic in some use cases where requests may be blocked by the receiving server for using particular IP addresses. Additionally, network blips or unreliable web services may lead to failed Vals if not handled properly.

--- a/src/content/docs/troubleshooting/exports.md
+++ b/src/content/docs/troubleshooting/exports.md
@@ -4,6 +4,7 @@ description: |
   Vals can export anything they want, but if you intend to use vals as
   web handlers, email handlers, or on a schedule, they'll need at least
   one export.
+lastUpdated: 2023-12-22
 ---
 
 Vals can export anything they want, but if you intend to use vals as

--- a/src/content/docs/troubleshooting/settimeout.mdx
+++ b/src/content/docs/troubleshooting/settimeout.mdx
@@ -1,6 +1,8 @@
 ---
 title: setTimeout
-description: You can use setTimeout in Val Town, but remember that vals are limited in how long they can run.
+description: You can use setTimeout in Val Town, but remember that vals are
+  limited in how long they can run.
+lastUpdated: 2023-12-15
 ---
 
 We don't limit the duration of your timeout, but we do limit the duration of

--- a/src/content/docs/types/email.mdx
+++ b/src/content/docs/types/email.mdx
@@ -3,6 +3,7 @@ title: Email
 description: A kind of val that is able to receive emails sent to it.
 sidebar:
   order: 4
+lastUpdated: 2023-12-22
 ---
 
 Email handler vals get their own email address that you can send email

--- a/src/content/docs/types/express.mdx
+++ b/src/content/docs/types/express.mdx
@@ -9,6 +9,7 @@ sidebar:
   badge:
     text: Deprecated
     variant: caution
+lastUpdated: 2023-12-22
 ---
 
 :::note

--- a/src/content/docs/types/http/basic-examples.mdx
+++ b/src/content/docs/types/http/basic-examples.mdx
@@ -1,6 +1,7 @@
 ---
 title: Basic examples
 generated: 1701279907946
+lastUpdated: 2023-12-15
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/types/http/index.mdx
+++ b/src/content/docs/types/http/index.mdx
@@ -1,9 +1,11 @@
 ---
 title: HTTP
-description: |
-  A kind of val that can serve a website or an API using web-standard Request & Response objects.
+description: >
+  A kind of val that can serve a website or an API using web-standard Request &
+  Response objects.
 sidebar:
   order: 0
+lastUpdated: 2023-12-22
 ---
 
 import { LinkCard } from "@astrojs/starlight/components";

--- a/src/content/docs/types/http/jsx.mdx
+++ b/src/content/docs/types/http/jsx.mdx
@@ -1,6 +1,8 @@
 ---
 title: HTML & JSX
-description: You can use JSX syntax in Val Town to render HTML using React, Preact, Vue, Solid, etc.
+description: You can use JSX syntax in Val Town to render HTML using React,
+  Preact, Vue, Solid, etc.
+lastUpdated: 2023-12-22
 ---
 
 Val Town supports server-rendered JSX. This lets you use JSX syntax to construct

--- a/src/content/docs/types/http/routing.mdx
+++ b/src/content/docs/types/http/routing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Routing
 generated: 1701279907950
+lastUpdated: 2023-12-22
 ---
 
 One of the coolest things about the Request/Response API is that it works with modern web frameworks, so you can use routing and their helper methods!

--- a/src/content/docs/types/scheduled.mdx
+++ b/src/content/docs/types/scheduled.mdx
@@ -2,7 +2,9 @@
 title: Scheduled
 sidebar:
   order: 1
-description: "Schedules let code on Val Town run every day, every hour, or whenever you'd like"
+description: Schedules let code on Val Town run every day, every hour, or
+  whenever you'd like
+lastUpdated: 2023-12-22
 ---
 
 You can schedule code to run repeatedly on Val Town. Want to check an RSS

--- a/src/content/docs/types/script.md
+++ b/src/content/docs/types/script.md
@@ -4,6 +4,7 @@ description: |
   The most flexible kind of val, a way to run any TypeScript and JavaScript
 sidebar:
   order: 2
+lastUpdated: 2023-12-05
 ---
 
 Script vals are free form JavaScript, TypeScript, or JSX. They are useful


### PR DESCRIPTION
- Fixes #93

Backfills using git. Cloudflare pages does a shallow clone so Starlight can't determine last-updated time.

Open sourced the tiny script that make this possible in an automated way: https://github.com/val-town/add-last-updated