### PR TITLE
Update to API docs

### DIFF
--- a/src/content/docs/api/aliases.mdx
+++ b/src/content/docs/api/aliases.mdx
@@ -14,6 +14,8 @@ lastUpdated: 2023-12-22
 
 ## GET `/v1/alias/{username}`
 
+Get a user profile information by their username
+
 ```ts title="Example" val
 import { alias } from "https://esm.town/v/neverstew/alias";
 
@@ -22,7 +24,9 @@ export let aliasExample = alias({
 });
 ```
 
-## GET `/v1/alias/{username}/{handle}`
+## GET `/v1/alias/{username}/{val_name}`
+
+Get a val by the author's username and val name
 
 ```ts title="Example" val
 import { alias } from "https://esm.town/v/neverstew/alias";

--- a/src/content/docs/api/my-resources.mdx
+++ b/src/content/docs/api/my-resources.mdx
@@ -18,6 +18,8 @@ This is the same as `/v1/users/{your_user_id}`
 
 :::
 
+Get profile information for the current user
+
 ```ts title="Example" val
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=41";
 
@@ -52,6 +54,8 @@ export let getRuns = runs({
 
 ## GET `/v1/me/likes`
 
+Get vals liked by the current user
+
 ```ts title="Example" val
 import { likes } from "https://esm.town/v/neverstew/likes";
 
@@ -63,6 +67,8 @@ export let getLikes = likes({
 ```
 
 ## GET `/v1/me/comments`
+
+Get comments related to current user, either given or received
 
 ```ts title="Example" val
 import { comments } from "https://esm.town/v/neverstew/comments";
@@ -77,3 +83,7 @@ export let getComments = comments({
   until: new Date(),
 });
 ```
+
+## Get `/v1/me/references`
+
+Returns vals that depend on any of the user's vals

--- a/src/content/docs/api/my-resources.mdx
+++ b/src/content/docs/api/my-resources.mdx
@@ -87,3 +87,14 @@ export let getComments = comments({
 ## Get `/v1/me/references`
 
 Returns vals that depend on any of the user's vals
+
+```ts title="Example" val
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=42";
+
+export const references = await fetchJSON(
+  "https://api.val.town/v1/me/references",
+  {
+    headers: { Authorization: `Bearer ${Deno.env.get("valtown")}` },
+  }
+);
+```

--- a/src/content/docs/api/run.mdx
+++ b/src/content/docs/api/run.mdx
@@ -16,28 +16,25 @@ You pass `args` to Run API function calls via a JSON-encoded array. While it may
 feel a bit clunky to always pass an array (even when passing a single argument),
 this is a clean and expressive way to accept any number of arguments.
 
-## GET `/v1/run/{handle}.{val}`
+## GET `/v1/run/{username}.{val_name}`
 
 ```ts title="Example" val
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 export let runGET = fetchJSON(
-  `https://api.val.town/v1/run/stevekrouse.add?args=${JSON.stringify([1, 2])}`,
+  `https://api.val.town/v1/run/stevekrouse.add?args=${JSON.stringify([1, 2])}`
 );
 ```
 
-## POST `/v1/run/{handle}.{val}`
+## POST `/v1/run/{username}.{val_name}`
 
 ```ts title="Example" val
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let runPOST = fetchJSON(
-  `https://api.val.town/v1/run/stevekrouse.add`,
-  {
-    method: "POST",
-    body: JSON.stringify({
-      args: [1, 2],
-    }),
-  },
-);
+export let runPOST = fetchJSON(`https://api.val.town/v1/run/stevekrouse.add`, {
+  method: "POST",
+  body: JSON.stringify({
+    args: [1, 2],
+  }),
+});
 ```

--- a/src/content/docs/api/users.mdx
+++ b/src/content/docs/api/users.mdx
@@ -8,6 +8,8 @@ lastUpdated: 2023-12-22
 
 ## GET `/v1/users/{user_id}`
 
+Get a user's profile information
+
 ```ts title="Example" val
 import { user } from "https://esm.town/v/neverstew/user";
 
@@ -17,6 +19,8 @@ export const userExample = user({
 ```
 
 ## GET `/v1/users/{user_id}/vals`
+
+List a user's vals
 
 ```ts title="Example" val
 import { userVals } from "https://esm.town/v/neverstew/userVals";

--- a/src/content/docs/api/vals.mdx
+++ b/src/content/docs/api/vals.mdx
@@ -8,16 +8,37 @@ The vals endpoints allow you to manipulate vals.
 
 ## POST `/v1/vals`
 
+Create a new val
+
 ```ts title="Example" val
-import { createVal } from "https://esm.town/v/neverstew/createVal";
+import { createVal } from "https://esm.town/v/nbbaier/createVal";
 
 export const postVals = createVal({
   token: Deno.env.get("valtown"),
+  name: "myNewVal",
   code: "const two = 1 + 1;",
+  readme: "Lorem ipsum dolor sit amet.",
+  privacy: "public",
+});
+```
+
+## PUT `/v1/vals`
+
+Create or update a val by name and code.
+
+```ts title="Example" val
+import { updateValByName } from "https://esm.town/v/nbbaier/updateValByName";
+
+export const updatedVal = updateValByName({
+  token: Deno.env.get("valtown"),
+  name: "myNewVal",
+  code: "const two = 2;",
 });
 ```
 
 ## GET `/v1/vals/{val_id}`
+
+Get val by id.
 
 ```ts title="Example" val
 import { val } from "https://esm.town/v/neverstew/val";
@@ -28,6 +49,8 @@ export const getVal = val({
 ```
 
 ## DELETE `/v1/vals/{val_id}`
+
+Delete a val.
 
 ```ts title="Example" val
 import { deleteVal } from "https://esm.town/v/neverstew/deleteVal";
@@ -40,6 +63,8 @@ export const deleteValExample = deleteVal({
 
 ## GET `/v1/vals/{val_id}/versions`
 
+List versions of a val
+
 ```ts title="Example" val
 import { valVersions } from "https://esm.town/v/neverstew/valVersions";
 
@@ -50,6 +75,8 @@ export const getValVersions = valVersions({
 ```
 
 ## POST `/v1/vals/{val_id}/versions`
+
+Create a new version of a val
 
 ```ts title="Example" val
 import { createValVersion } from "https://esm.town/v/neverstew/createValVersion";
@@ -73,6 +100,8 @@ export let createValVersionExample = (() =>
 
 ## GET `/v1/vals/{val_id}/versions/{version}`
 
+Get a specific version of a val
+
 ```ts title="Example" val
 import { valVersion } from "https://esm.town/v/neverstew/valVersion";
 
@@ -84,6 +113,8 @@ export const getValVersion = valVersion({
 ```
 
 ## DELETE `/v1/vals/{val_id}/versions/{version}`
+
+Delete a val version.
 
 ```ts title="Example" val
 import { deleteValVersion } from "https://esm.town/v/neverstew/deleteValVersion";


### PR DESCRIPTION
I've updated the API documentation in the following way:

- Added descriptions from the [OpenAPI Spec](https://www.val.town/docs/openapi.yaml) to each endpoint in the docs
- Updated the example for `POST /v1/vals` to reflect that it is possible to include readme and privacy in the request body
- Added the `PUT /v1/vals` endpoint and added an example for it
- Added the `GET /v1/me/references` endpoint and example for it
- Changed `handle` where it was used in the API docs to better reflect what the path parameter is (it was used for both val_name and username)
- 

Partially resolves #100 