### PR TITLE
Async docs draft

### DIFF
--- a/src/content/docs/types/http/basic-examples.mdx
+++ b/src/content/docs/types/http/basic-examples.mdx
@@ -2,6 +2,8 @@
 title: Basic examples
 generated: 1701279907946
 lastUpdated: 2023-12-15
+sidebar:
+  order: 1
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -17,8 +17,8 @@ later.
 
 You can defer work by two mechanisms:
 
-- Creating a Promise or async function (recommended)
-- Using setTimeout or setInterval
+- Creating a `Promise` or async function (recommended)
+- Using `setTimeout` or `setInterval`
 
 Here's an example of deferring work using an anonymous
 async function. This val responds to HTTP requests
@@ -36,23 +36,6 @@ export async function handle() {
     // Log a message
     console.log("Hi!");
   })();
-  return Response.json({ ok: true });
-}
-```
-
-The same approach works if you use a `Promise` object:
-
-```ts title="Unawaited promise" val
-export async function handle() {
-  // Schedule work to do later
-  new Promise<void>(async (resolve) => {
-    // Wait 1 second
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    // Log a message
-    console.log("Hi!");
-    // Finish the work
-    resolve();
-  });
   return Response.json({ ok: true });
 }
 ```

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -1,8 +1,10 @@
 ---
-title: Early-returning HTTP responses
+title: Deferred functions
 description: |
   You can do asynchronous work after return a response from
   an HTTP handler.
+sidebar:
+  order: 5
 lastUpdated: 2024-01-31
 ---
 
@@ -13,10 +15,10 @@ HTTP responses as soon as they're returned from the handler method. So
 you can return a response immediately and defer additional work until
 later.
 
-You can defer work by three mechanisms:
+You can defer work by two mechanisms:
 
 - Creating a Promise or async function (recommended)
-- Using setTimeout
+- Using setTimeout or setInterval
 
 Here's an example of deferring work using an anonymous
 async function. This val responds to HTTP requests

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -1,0 +1,60 @@
+---
+title: Early-returning HTTP responses
+description: |
+  You can do asynchronous work after return a response from
+  an HTTP handler.
+lastUpdated: 2024-01-31
+---
+
+If you need to return an HTTP response first, and then do additional
+asynchronous work, you can do that with Val Town. Vals by default wait
+until all Promises and timeouts are resolved before exiting, but send
+HTTP responses as soon as they're returned from the handler method. So
+you can return a response immediately and defer additional work until
+later.
+
+You can defer work by three mechanisms:
+
+- Creating a Promise or async function (recommended)
+- Using setTimeout
+
+Here's an example of deferring work using an anonymous
+async function. This val responds to HTTP requests
+with `{ "ok": true }` immediately, and then waits a second,
+and then logs the word "Hi!". You can use the same structure
+to schedule time-consuming work like database queries
+or network traffic till after the Val's response is already sent.
+
+```ts title="Unawaited async function" val
+export async function handle() {
+  // Schedule work to do later
+  (async () => {
+    // Wait 1 second
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Log a message
+    console.log("Hi!");
+  })();
+  return Response.json({ ok: true });
+}
+```
+
+The same approach works if you use a `Promise` object:
+
+```ts title="Unawaited promise" val
+export async function handle() {
+  // Schedule work to do later
+  new Promise<void>(async (resolve) => {
+    // Wait 1 second
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Log a message
+    console.log("Hi!");
+    // Finish the work
+    resolve();
+  });
+  return Response.json({ ok: true });
+}
+```
+
+The key to both techniques is that the async work does
+_not_ use the `await` keyword, so JavaScript does not wait
+for it to finish before returning the Response object.

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -8,17 +8,19 @@ sidebar:
 lastUpdated: 2024-01-31
 ---
 
-If you need to return an HTTP response first, and then do additional
-asynchronous work, you can do that with Val Town. Vals by default wait
-until all Promises and timeouts are resolved before exiting, but send
-HTTP responses as soon as they're returned from the handler method. So
-you can return a response immediately and defer additional work until
-later.
+Val Town supports asynchronous functions with the basic primitives
+of [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
+in JavaScript. All kinds of handler vals, including HTTP, Email,
+and Interval, can be async functions: if they return a Promise,
+we await it.
 
-You can defer work by two mechanisms:
+We also wait until other, non-awaited asynchronous work is done
+before exiting from a Val: we wait for the runtime to gracefully
+exit after all promises have resolved.
 
-- Creating a `Promise` or async function (recommended)
-- Using `setTimeout` or `setInterval`
+You can use this feature to make an HTTP val that responds quickly
+to an incoming HTTP request, and then does some other work
+_after_ sending a response.
 
 Here's an example of deferring work using an anonymous
 async function. This val responds to HTTP requests
@@ -43,3 +45,34 @@ export async function handle() {
 The key to both techniques is that the async work does
 _not_ use the `await` keyword, so JavaScript does not wait
 for it to finish before returning the Response object.
+
+### waitUntil
+
+This technique is a stopgap until full support for
+[waitUntil](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil)
+lands in Val Town, which will handle this case more explicitly.
+
+### Promises should otherwise be awaited
+
+While this is a  useful technique, it's important to emphasize that,
+in general, you should otherwise `await` every Promise.
+If you don't remember to use `await` with Promises - besides this
+narrow usecase, errors that occur in promises won't be properly
+handled and functions may run out-of-order.
+
+For example, if you use `fetch` to request some resource,
+but forget to await it, then it won't throw errors when it fails,
+and you won't have the values you expect to have:
+
+```ts
+export async function handle() {
+  try {
+    // Result will be an opaque Promise, not a useful value.
+    const result = fetch('https://google.com/');
+  } catch (e) {
+    // Errors will never be caught here because
+    // fetch is not awaited.
+    handleError(e);
+  }
+}
+```

--- a/src/content/docs/types/http/index.mdx
+++ b/src/content/docs/types/http/index.mdx
@@ -34,6 +34,8 @@ export function handler(request: Request) {
 
 <LinkCard title="Rendering HTML & JSX" href="/types/http/jsx" />
 
+<LinkCard title="Early-returning responses" href="/types/http/early-return" />
+
 ## Limitations
 
 The maximum size for requests is 2mb and the maximum size for responses is 250kb.

--- a/src/content/docs/types/http/jsx.mdx
+++ b/src/content/docs/types/http/jsx.mdx
@@ -3,6 +3,8 @@ title: HTML & JSX
 description: You can use JSX syntax in Val Town to render HTML using React,
   Preact, Vue, Solid, etc.
 lastUpdated: 2023-12-22
+sidebar:
+  order: 2
 ---
 
 Val Town supports server-rendered JSX. This lets you use JSX syntax to construct

--- a/src/content/docs/types/http/routing.mdx
+++ b/src/content/docs/types/http/routing.mdx
@@ -2,6 +2,8 @@
 title: Routing
 generated: 1701279907950
 lastUpdated: 2024-01-16
+sidebar:
+  order: 3
 ---
 
 One of the coolest things about the Request/Response API is that it works with modern web frameworks, so you can use routing and their helper methods!


### PR DESCRIPTION
Adds a new section to the HTTP val type docs about early-returning HTTP responses.