### PR TITLE
Update outdated Turso docs links

### DIFF
--- a/src/content/docs/std/SQLite/usage.mdx
+++ b/src/content/docs/std/SQLite/usage.mdx
@@ -6,7 +6,7 @@ sidebar:
 lastUpdated: 2023-12-27
 ---
 
-Val Town [SQLite val](https://www.val.town/v/std/sqlite) has two methods: `execute` [↗](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#execute-a-single-statement) and `batch` [↗](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#batches-and-interactive-transactions). Below are examples of how to use them in Val Town.
+Val Town [SQLite val](https://www.val.town/v/std/sqlite) has two methods: `execute` [↗](https://docs.turso.tech/sdk/ts/reference#simple-query) and `batch` [↗](https://docs.turso.tech/sdk/ts/reference#batch-transactions). Below are examples of how to use them in Val Town.
 
 ## Simple query
 


### PR DESCRIPTION
Closes #131 

Previous links were redirecting to a generic "Introduction" page of Turso docs.