### PR TITLE
Add Val Town to titles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
   integrations: [
     starlightLinksValidator(),
     starlight({
-      title: "Docs",
+      title: "Docs | Val Town",
       defaultLocale: "root",
       components: {
         Footer: "./src/components/Footer.astro",


### PR DESCRIPTION
Noticed that our docs page titles don't include "Val Town" and I suspect that they would have better SEO & recognizability if they did.