### PR TITLE
Add interactive samples in the REST API section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -134,6 +134,14 @@ export default defineConfig({
           },
         },
         {
+          tag: "script",
+          attrs: {
+            src: "https://raw.esm.sh/vt-playground@latest/dist/vt-playground.js",
+            defer: true,
+            type: "module",
+          },
+        },
+        {
           tag: "link",
           attrs: {
             href: "https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css",

--- a/src/components/Val.astro
+++ b/src/components/Val.astro
@@ -1,12 +1,16 @@
 ---
-const { code, disabled = false } = Astro.props;
+const { url } = Astro.props;
 ---
 
-<script
-  type="module"
-  src="http://cdn.jsdelivr.net/npm/vt-playground@0.1.4/dist/vt-playground.js"
-></script>
-
 <div class="not-content">
-  <vt-playground code={code} {disabled}></vt-playground>
+  <iframe
+    title="Embedded interactive val"
+    src={url}
+    width="100%"
+    height="400px"
+    style="border: none;"
+    loading="lazy"
+  >
+    &#x20;
+  </iframe>
 </div>

--- a/src/components/Val.astro
+++ b/src/components/Val.astro
@@ -4,7 +4,7 @@ const { code, disabled = false } = Astro.props;
 
 <script
   type="module"
-  src="http://cdn.jsdelivr.net/npm/vt-playground@0.1.3/dist/vt-playground.js"
+  src="http://cdn.jsdelivr.net/npm/vt-playground@0.1.4/dist/vt-playground.js"
 ></script>
 
 <div class="not-content">

--- a/src/components/Val.astro
+++ b/src/components/Val.astro
@@ -1,15 +1,12 @@
 ---
-const { url } = Astro.props;
+const { code, disabled = false } = Astro.props;
 ---
 
+<script
+  type="module"
+  src="http://cdn.jsdelivr.net/npm/vt-playground@0.1.3/dist/vt-playground.js"
+></script>
+
 <div class="not-content">
-  <iframe
-    title="Embedded interactive val"
-    src={url}
-    width="100%"
-    height="400px"
-    style="border: none;"
-    loading="lazy">
-    &#x20;
-  </iframe>
+  <vt-playground code={code} {disabled}></vt-playground>
 </div>

--- a/src/content/docs/api/aliases.mdx
+++ b/src/content/docs/api/aliases.mdx
@@ -6,6 +6,8 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
+import Val from '@components/Val.astro'
+
 :::note
 
 💡 These endpoints accept a `token` parameter for private vals
@@ -16,25 +18,19 @@ lastUpdated: 2023-12-22
 
 Get a user profile information by their username
 
-```ts title="Example" val
-import { alias } from "https://esm.town/v/neverstew/alias";
+<Val code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let aliasExample = alias({
-  username: "stevekrouse",
-});
-```
+console.log(await fetchJSON("https://api.val.town/v1/alias/stevekrouse"));
+`.trim()}/>
+
 
 ## GET `/v1/alias/{username}/{val_name}`
 
 Get a val by the author's username and val name
 
-```ts title="Example" val
-import { alias } from "https://esm.town/v/neverstew/alias";
+<Val code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export const aliasValExample = alias({
-  username: "stevekrouse",
-  valName: "parentReference",
-  // for private vals, pass your val town api token
-  // token: Deno.env.get("valtown")
-});
-```
+console.log(await fetchJSON("https://api.val.town/v1/alias/stevekrouse/fetchJSON"));
+`.trim()}/>

--- a/src/content/docs/api/aliases.mdx
+++ b/src/content/docs/api/aliases.mdx
@@ -6,8 +6,6 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
-import Val from '@components/Val.astro'
-
 :::note
 
 💡 These endpoints accept a `token` parameter for private vals
@@ -18,18 +16,18 @@ import Val from '@components/Val.astro'
 
 Get a user profile information by their username
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON("https://api.val.town/v1/alias/stevekrouse"));
-`.trim()}/>
+`.trim()}></vt-playground>
 
 
 ## GET `/v1/alias/{username}/{val_name}`
 
 Get a val by the author's username and val name
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON("https://api.val.town/v1/alias/stevekrouse/fetchJSON"));

--- a/src/content/docs/api/eval.mdx
+++ b/src/content/docs/api/eval.mdx
@@ -6,8 +6,6 @@ generated: 1701279907968
 lastUpdated: 2023-12-22
 ---
 
-import Val from '@components/Val.astro'
-
 The Eval API lets you run arbitrary JavaScript/TypeScript, with full access to
 the Val Town runtime.
 
@@ -33,7 +31,7 @@ You can compute with references to public vals, like
 
 Pass the `code` expression to be evaluated via a JSON-encoded body, like so:
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await (fetchJSON(
@@ -47,7 +45,7 @@ console.log(await (fetchJSON(
 
 You can also pass arguments if the `code` parameter represents a function:
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON(

--- a/src/content/docs/api/eval.mdx
+++ b/src/content/docs/api/eval.mdx
@@ -6,6 +6,8 @@ generated: 1701279907968
 lastUpdated: 2023-12-22
 ---
 
+import Val from '@components/Val.astro'
+
 The Eval API lets you run arbitrary JavaScript/TypeScript, with full access to
 the Val Town runtime.
 
@@ -31,28 +33,28 @@ You can compute with references to public vals, like
 
 Pass the `code` expression to be evaluated via a JSON-encoded body, like so:
 
-```ts title="Example" val
+<Val code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let evalPost1 = fetchJSON(
+console.log(await (fetchJSON(
   "https://api.val.town/v1/eval",
   {
     method: "POST",
     body: JSON.stringify({ code: "1+1" }),
   },
-);
-```
+)));
+`.trim()} />
 
 You can also pass arguments if the `code` parameter represents a function:
 
-```ts title="Example" val
+<Val code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let evalPost2 = fetchJSON(
+console.log(await fetchJSON(
   "https://api.val.town/v1/eval",
   {
     method: "POST",
     body: JSON.stringify({ code: "(a,b) => a+b", args: [1, 2] }),
   },
-);
-```
+));
+`.trim()} />

--- a/src/content/docs/api/my-resources.mdx
+++ b/src/content/docs/api/my-resources.mdx
@@ -7,6 +7,8 @@ description: >
 lastUpdated: 2023-12-22
 ---
 
+import Val from '@components/Val.astro'
+
 When using the Val Town API, some of the most common functions operate on things
 that you own. For these kinds of operations, there are the "me" routes.
 
@@ -20,15 +22,15 @@ This is the same as `/v1/users/{your_user_id}`
 
 Get profile information for the current user
 
-```ts title="Example" val
+<Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=41";
 
-export let getMe = fetchJSON(`https://api.val.town/v1/me`, {
+console.log(await fetchJSON(\`https://api.val.town/v1/me\`, {
   headers: {
-    Authorization: `Bearer ${Deno.env.get("valtown")}`,
+    Authorization: \`Bearer \${Deno.env.get("valtown")}\`,
   },
-});
-```
+}));
+`.trim()} />
 
 ## GET `/v1/me/runs`
 
@@ -38,10 +40,10 @@ This is currently the only way to list runs across multiple vals.
 
 :::
 
-```ts title="Example" val
+<Val disabled code={`
 import { runs } from "https://esm.town/v/stevekrouse/runs?v=17";
 
-export let getRuns = runs({
+console.log(await runs({
   token: Deno.env.get("valtown"),
   error: false,
   limit: 10,
@@ -49,31 +51,31 @@ export let getRuns = runs({
   // last 30 minutes
   since: new Date(Number(new Date()) - 1800000),
   until: new Date(),
-});
-```
+}));
+`.trim()} />
 
 ## GET `/v1/me/likes`
 
 Get vals liked by the current user
 
-```ts title="Example" val
+<Val disabled code={`
 import { likes } from "https://esm.town/v/neverstew/likes";
 
-export let getLikes = likes({
+console.log(likes({
   token: Deno.env.get("valtown"),
   limit: 10,
   offset: 0,
-});
-```
+}));
+`} />
 
 ## GET `/v1/me/comments`
 
 Get comments related to current user, either given or received
 
-```ts title="Example" val
+<Val disabled code={`
 import { comments } from "https://esm.town/v/neverstew/comments";
 
-export let getComments = comments({
+console.log(comments({
   token: Deno.env.get("valtown"),
   relationship: "any",
   limit: 10,
@@ -81,20 +83,20 @@ export let getComments = comments({
   // last 30 minutes
   since: new Date(Number(new Date()) - 1800000),
   until: new Date(),
-});
-```
+}))
+`.trim()} />
 
-## Get `/v1/me/references`
+## GET `/v1/me/references`
 
-Returns vals that depend on any of the user's vals
+Returns vals that depend on any of the user’s vals
 
-```ts title="Example" val
+<Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=42";
 
-export const references = await fetchJSON(
+console.log(await fetchJSON(
   "https://api.val.town/v1/me/references",
   {
-    headers: { Authorization: `Bearer ${Deno.env.get("valtown")}` },
+    headers: { Authorization: \`Bearer \${Deno.env.get("valtown")}\` },
   }
-);
-```
+))
+`.trim()} />

--- a/src/content/docs/api/my-resources.mdx
+++ b/src/content/docs/api/my-resources.mdx
@@ -7,8 +7,6 @@ description: >
 lastUpdated: 2023-12-22
 ---
 
-import Val from '@components/Val.astro'
-
 When using the Val Town API, some of the most common functions operate on things
 that you own. For these kinds of operations, there are the "me" routes.
 
@@ -22,7 +20,7 @@ This is the same as `/v1/users/{your_user_id}`
 
 Get profile information for the current user
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=41";
 
 console.log(await fetchJSON(\`https://api.val.town/v1/me\`, {
@@ -40,7 +38,7 @@ This is currently the only way to list runs across multiple vals.
 
 :::
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { runs } from "https://esm.town/v/stevekrouse/runs?v=17";
 
 console.log(await runs({
@@ -58,7 +56,7 @@ console.log(await runs({
 
 Get vals liked by the current user
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { likes } from "https://esm.town/v/neverstew/likes";
 
 console.log(likes({
@@ -72,7 +70,7 @@ console.log(likes({
 
 Get comments related to current user, either given or received
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { comments } from "https://esm.town/v/neverstew/comments";
 
 console.log(comments({
@@ -90,7 +88,7 @@ console.log(comments({
 
 Returns vals that depend on any of the user’s vals
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=42";
 
 console.log(await fetchJSON(

--- a/src/content/docs/api/run.mdx
+++ b/src/content/docs/api/run.mdx
@@ -10,8 +10,6 @@ sidebar:
 lastUpdated: 2024-02-07
 ---
 
-import Val from "@components/Val.astro";
-
 :::caution[Deprecated]
 
 The Run API is deprecated. Only select vals can be invoked through it.
@@ -34,7 +32,7 @@ this is a clean and expressive way to accept any number of arguments.
 
 ## GET `/v1/run/{username}.{val_name}`
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON(
@@ -44,7 +42,7 @@ console.log(await fetchJSON(
 
 ## POST `/v1/run/{username}.{val_name}`
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON(\`https://api.val.town/v1/run/stevekrouse.add\`, {

--- a/src/content/docs/api/run.mdx
+++ b/src/content/docs/api/run.mdx
@@ -10,6 +10,7 @@ sidebar:
 lastUpdated: 2024-02-07
 ---
 
+import Val from "@components/Val.astro";
 
 :::caution[Deprecated]
 
@@ -33,23 +34,23 @@ this is a clean and expressive way to accept any number of arguments.
 
 ## GET `/v1/run/{username}.{val_name}`
 
-```ts title="Example" val
+<Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 export let runGET = fetchJSON(
-  `https://api.val.town/v1/run/stevekrouse.add?args=${JSON.stringify([1, 2])}`
+  \`https://api.val.town/v1/run/stevekrouse.add?args=${JSON.stringify([1, 2])}\`
 );
-```
+`.trim()} />
 
 ## POST `/v1/run/{username}.{val_name}`
 
-```ts title="Example" val
+<Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let runPOST = fetchJSON(`https://api.val.town/v1/run/stevekrouse.add`, {
+export let runPOST = fetchJSON(\`https://api.val.town/v1/run/stevekrouse.add\`, {
   method: "POST",
   body: JSON.stringify({
     args: [1, 2],
   }),
 });
-```
+`.trim()} />

--- a/src/content/docs/api/run.mdx
+++ b/src/content/docs/api/run.mdx
@@ -37,9 +37,9 @@ this is a clean and expressive way to accept any number of arguments.
 <Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let runGET = fetchJSON(
-  \`https://api.val.town/v1/run/stevekrouse.add?args=${JSON.stringify([1, 2])}\`
-);
+console.log(await fetchJSON(
+  \`https://api.val.town/v1/run/stevekrouse.add?args=\${JSON.stringify([1, 2])}\`
+));
 `.trim()} />
 
 ## POST `/v1/run/{username}.{val_name}`
@@ -47,10 +47,10 @@ export let runGET = fetchJSON(
 <Val disabled code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let runPOST = fetchJSON(\`https://api.val.town/v1/run/stevekrouse.add\`, {
+console.log(await fetchJSON(\`https://api.val.town/v1/run/stevekrouse.add\`, {
   method: "POST",
   body: JSON.stringify({
     args: [1, 2],
   }),
-});
+}));
 `.trim()} />

--- a/src/content/docs/api/users.mdx
+++ b/src/content/docs/api/users.mdx
@@ -6,26 +6,24 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 ## GET `/v1/users/{user_id}`
 
 Get a user's profile information
 
-```ts title="Example" val
-import { user } from "https://esm.town/v/neverstew/user";
+<Val code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export const userExample = user({
-  id: "a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18",
-});
-```
+console.log(await fetchJSON("https://api.val.town/v1/users/a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18/vals"));
+`.trim()} />
 
 ## GET `/v1/users/{user_id}/vals`
 
 List a user's vals
 
-```ts title="Example" val
-import { userVals } from "https://esm.town/v/neverstew/userVals";
+<Val code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export const userValsExample = userVals({
-  id: "a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18",
-});
-```
+console.log(await fetchJSON("https://api.val.town/v1/users/a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18/vals"));
+`.trim()} />

--- a/src/content/docs/api/users.mdx
+++ b/src/content/docs/api/users.mdx
@@ -6,13 +6,11 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
-import Val from "@components/Val.astro";
-
 ## GET `/v1/users/{user_id}`
 
 Get a user's profile information
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON("https://api.val.town/v1/users/a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18/vals"));
@@ -22,7 +20,7 @@ console.log(await fetchJSON("https://api.val.town/v1/users/a0bf3b31-15a5-4d5c-88
 
 List a user's vals
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON("https://api.val.town/v1/users/a0bf3b31-15a5-4d5c-880e-4b1e22c9bc18/vals"));

--- a/src/content/docs/api/vals.mdx
+++ b/src/content/docs/api/vals.mdx
@@ -11,14 +11,20 @@ The vals endpoints allow you to manipulate vals.
 Create a new val
 
 <vt-playground disabled code={`
-import { createVal } from "https://esm.town/v/nbbaier/createVal";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await createVal({
-  token: Deno.env.get("valtown"),
-  name: "myNewVal",
-  code: "const two = 1 + 1;",
-  readme: "Lorem ipsum dolor sit amet.",
-  privacy: "public",
+console.log(await fetchJSON("https://api.val.town/v1/vals", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
+  body: JSON.stringify({
+    name: "myNewVal",
+    code: "const two = 1 + 1;",
+    readme: "Lorem ipsum dolor sit amet.",
+    privacy: "public",
+  }),
 }));
 `.trim()} />
 
@@ -27,12 +33,18 @@ console.log(await createVal({
 Create or update a val by name and code.
 
 <vt-playground disabled code={`
-import { updateValByName } from "https://esm.town/v/nbbaier/updateValByName";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await updateValByName({
-  token: Deno.env.get("valtown"),
-  name: "myNewVal",
-  code: "const two = 2;",
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e", {
+  method: "PUT",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
+  body: JSON.stringify({
+    name: "myNewVal",
+    code: "const two = 2;",
+  }),
 }));
 `.trim()} />
 
@@ -51,11 +63,14 @@ console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8c
 Delete a val.
 
 <vt-playground disabled code={`
-import { deleteVal } from "https://esm.town/v/neverstew/deleteVal";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await deleteVal({
-  token: Deno.env.get("valtown"),
-  id: "1f32d4c1-332e-4135-889f-8df408924a9d",
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e", {
+  method: "DELETE",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
 }));
 `.trim()} />
 
@@ -64,11 +79,12 @@ console.log(await deleteVal({
 List versions of a val
 
 <vt-playground disabled code={`
-import { valVersions } from "https://esm.town/v/neverstew/valVersions";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await valVersions({
-  token: Deno.env.get("valtown"),
-  id: "0cfbf317-18a4-4da5-b887-b75bb8a33108",
+console.log(await fetchJSON("https://api.val.town/v1/vals/0cfbf317-18a4-4da5-b887-b75bb8a33108/versions", {
+  headers: {
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
 }));
 `.trim()} />
 
@@ -77,23 +93,18 @@ console.log(await valVersions({
 Create a new version of a val
 
 <vt-playground disabled code={`
-import { createValVersion } from "https://esm.town/v/neverstew/createValVersion";
-import { val as val2 } from "https://esm.town/v/neverstew/val";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await (() =>
-  val2({
-    token: Deno.env.get("valtown"),
-    id: "543ae134-636f-43a7-bd7f-f766a3d52b47",
-  })
-    .then((val) => ({ id: val.id, code: val.code }))
-    .then(({ id, code }) =>
-      createValVersion({
-        token: Deno.env.get("valtown"),
-        code: \`// my inserted comment
-      \${code}\`,
-        valId: id,
-      })
-    ))());
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e/versions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
+  body: JSON.stringify({
+    code: "const two = 2;",
+  }),
+}));
 `.trim()} />
 
 ## GET `/v1/vals/{val_id}/versions/{version}`
@@ -101,12 +112,12 @@ console.log(await (() =>
 Get a specific version of a val
 
 <vt-playground disabled code={`
-import { valVersion } from "https://esm.town/v/neverstew/valVersion";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-console.log(await valVersion({
-  token: Deno.env.get("valtown"),
-  id: "7f9019e4-dbf8-4ebe-b8cd-67730697624e",
-  version: 4,
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e/versions/1", {
+  headers: {
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
 }));
 `.trim()} />
 
@@ -115,24 +126,27 @@ console.log(await valVersion({
 Delete a val version.
 
 <vt-playground disabled code={`
-import { deleteValVersion } from "https://esm.town/v/neverstew/deleteValVersion";
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export let deleteValVersionExample = deleteValVersion({
-  token: Deno.env.get("valtown"),
-  id: "543ae134-636f-43a7-bd7f-f766a3d52b47",
-  version: 1,
-});
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e/versions/1", {
+  method: "DELETE",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
+}));
 `.trim()} />
 
 ## GET `/v1/vals/{val_id}/runs`
 
-<vt-playground disabled code={`
-import { valRuns } from "https://esm.town/v/neverstew/valRuns";
+List runs of a val.
 
-console.log(await valRuns({
-  token: Deno.env.get("valtown"),
-  id: "ae941dc9-97e5-4e2e-a25a-e07b733230ae",
-  limit: 1,
-  offset: 1,
+<vt-playground disabled code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
+
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e/runs", {
+  headers: {
+    "Authorization": "Bearer " + Deno.env.get("valtown"),
+  },
 }));
 `.trim()} />

--- a/src/content/docs/api/vals.mdx
+++ b/src/content/docs/api/vals.mdx
@@ -4,85 +4,85 @@ generated: 1701279907985
 lastUpdated: 2023-12-22
 ---
 
+import Val from '@components/Val.astro'
+
 The vals endpoints allow you to manipulate vals.
 
 ## POST `/v1/vals`
 
 Create a new val
 
-```ts title="Example" val
+<Val disabled code={`
 import { createVal } from "https://esm.town/v/nbbaier/createVal";
 
-export const postVals = createVal({
+console.log(await createVal({
   token: Deno.env.get("valtown"),
   name: "myNewVal",
   code: "const two = 1 + 1;",
   readme: "Lorem ipsum dolor sit amet.",
   privacy: "public",
-});
-```
+}));
+`.trim()} />
 
 ## PUT `/v1/vals`
 
 Create or update a val by name and code.
 
-```ts title="Example" val
+<Val disabled code={`
 import { updateValByName } from "https://esm.town/v/nbbaier/updateValByName";
 
-export const updatedVal = updateValByName({
+console.log(await updateValByName({
   token: Deno.env.get("valtown"),
   name: "myNewVal",
   code: "const two = 2;",
-});
-```
+}));
+`.trim()} />
 
 ## GET `/v1/vals/{val_id}`
 
 Get val by id.
 
-```ts title="Example" val
-import { val } from "https://esm.town/v/neverstew/val";
+<Val code={`
+import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
-export const getVal = val({
-  id: "7f9019e4-dbf8-4ebe-b8cd-67730697624e",
-});
-```
+console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e"));
+`.trim()} />
 
 ## DELETE `/v1/vals/{val_id}`
 
 Delete a val.
 
-```ts title="Example" val
+<Val disabled code={`
 import { deleteVal } from "https://esm.town/v/neverstew/deleteVal";
 
-export const deleteValExample = deleteVal({
+console.log(await deleteVal({
   token: Deno.env.get("valtown"),
   id: "1f32d4c1-332e-4135-889f-8df408924a9d",
-});
-```
+}));
+`.trim()} />
 
 ## GET `/v1/vals/{val_id}/versions`
 
 List versions of a val
 
-```ts title="Example" val
+<Val disabled code={`
 import { valVersions } from "https://esm.town/v/neverstew/valVersions";
 
-export const getValVersions = valVersions({
+console.log(await valVersions({
   token: Deno.env.get("valtown"),
   id: "0cfbf317-18a4-4da5-b887-b75bb8a33108",
-});
-```
+}));
+`.trim()} />
 
 ## POST `/v1/vals/{val_id}/versions`
 
 Create a new version of a val
 
-```ts title="Example" val
+<Val disabled code={`
 import { createValVersion } from "https://esm.town/v/neverstew/createValVersion";
 import { val as val2 } from "https://esm.town/v/neverstew/val";
 
-export let createValVersionExample = (() =>
+console.log(await (() =>
   val2({
     token: Deno.env.get("valtown"),
     id: "543ae134-636f-43a7-bd7f-f766a3d52b47",
@@ -91,32 +91,32 @@ export let createValVersionExample = (() =>
     .then(({ id, code }) =>
       createValVersion({
         token: Deno.env.get("valtown"),
-        code: `// my inserted comment
-      ${code}`,
+        code: \`// my inserted comment
+      \${code}\`,
         valId: id,
       })
-    ))();
-```
+    ))());
+`.trim()} />
 
 ## GET `/v1/vals/{val_id}/versions/{version}`
 
 Get a specific version of a val
 
-```ts title="Example" val
+<Val disabled code={`
 import { valVersion } from "https://esm.town/v/neverstew/valVersion";
 
-export const getValVersion = valVersion({
+console.log(await valVersion({
   token: Deno.env.get("valtown"),
   id: "7f9019e4-dbf8-4ebe-b8cd-67730697624e",
   version: 4,
-});
-```
+}));
+`.trim()} />
 
 ## DELETE `/v1/vals/{val_id}/versions/{version}`
 
 Delete a val version.
 
-```ts title="Example" val
+<Val disabled code={`
 import { deleteValVersion } from "https://esm.town/v/neverstew/deleteValVersion";
 
 export let deleteValVersionExample = deleteValVersion({
@@ -124,17 +124,17 @@ export let deleteValVersionExample = deleteValVersion({
   id: "543ae134-636f-43a7-bd7f-f766a3d52b47",
   version: 1,
 });
-```
+`.trim()} />
 
 ## GET `/v1/vals/{val_id}/runs`
 
-```ts title="Example" val
+<Val disabled code={`
 import { valRuns } from "https://esm.town/v/neverstew/valRuns";
 
-export const valRunsExample = valRuns({
+console.log(await valRuns({
   token: Deno.env.get("valtown"),
   id: "ae941dc9-97e5-4e2e-a25a-e07b733230ae",
   limit: 1,
   offset: 1,
-});
-```
+}));
+`.trim()} />

--- a/src/content/docs/api/vals.mdx
+++ b/src/content/docs/api/vals.mdx
@@ -4,15 +4,13 @@ generated: 1701279907985
 lastUpdated: 2023-12-22
 ---
 
-import Val from '@components/Val.astro'
-
 The vals endpoints allow you to manipulate vals.
 
 ## POST `/v1/vals`
 
 Create a new val
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { createVal } from "https://esm.town/v/nbbaier/createVal";
 
 console.log(await createVal({
@@ -28,7 +26,7 @@ console.log(await createVal({
 
 Create or update a val by name and code.
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { updateValByName } from "https://esm.town/v/nbbaier/updateValByName";
 
 console.log(await updateValByName({
@@ -42,7 +40,7 @@ console.log(await updateValByName({
 
 Get val by id.
 
-<Val code={`
+<vt-playground code={`
 import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";
 
 console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8cd-67730697624e"));
@@ -52,7 +50,7 @@ console.log(await fetchJSON("https://api.val.town/v1/vals/7f9019e4-dbf8-4ebe-b8c
 
 Delete a val.
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { deleteVal } from "https://esm.town/v/neverstew/deleteVal";
 
 console.log(await deleteVal({
@@ -65,7 +63,7 @@ console.log(await deleteVal({
 
 List versions of a val
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { valVersions } from "https://esm.town/v/neverstew/valVersions";
 
 console.log(await valVersions({
@@ -78,7 +76,7 @@ console.log(await valVersions({
 
 Create a new version of a val
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { createValVersion } from "https://esm.town/v/neverstew/createValVersion";
 import { val as val2 } from "https://esm.town/v/neverstew/val";
 
@@ -102,7 +100,7 @@ console.log(await (() =>
 
 Get a specific version of a val
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { valVersion } from "https://esm.town/v/neverstew/valVersion";
 
 console.log(await valVersion({
@@ -116,7 +114,7 @@ console.log(await valVersion({
 
 Delete a val version.
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { deleteValVersion } from "https://esm.town/v/neverstew/deleteValVersion";
 
 export let deleteValVersionExample = deleteValVersion({
@@ -128,7 +126,7 @@ export let deleteValVersionExample = deleteValVersion({
 
 ## GET `/v1/vals/{val_id}/runs`
 
-<Val disabled code={`
+<vt-playground disabled code={`
 import { valRuns } from "https://esm.town/v/neverstew/valRuns";
 
 console.log(await valRuns({


### PR DESCRIPTION
This makes uses of the `vt-playground` web components.

<img width="1552" alt="image" src="https://github.com/val-town/val-town-docs/assets/17577332/1395ec3f-e1ad-41eb-8ecb-2a9ccc33ffe7">

I found out multiple broken vals while editing the examples, so I updated them.

I would advise to only import `fetchJSON` in the api examples. 
Wrapping the logic in other vals makes a lot of example useless. ex:

```ts

import { alias } from "https://esm.town/v/neverstew/alias";

export let aliasExample = alias({ //
  username: "stevekrouse",
});
```

This example requires you to read the `neverstew/alias` val, so I converted it to:

```ts
import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON";

console.log(await fetchJSON("https://api.val.town/v1/alias/stevekrouse"));
```