### PR TITLE
Replace some code blocks intended to be HTTP vals with embed equivalents

### DIFF
--- a/plugins/val-town-open-button.mjs
+++ b/plugins/val-town-open-button.mjs
@@ -52,6 +52,7 @@ export function valTownOpenButton() {
 
         // Only run on blocks marked with `val` meta
         const meta = codeBlock.meta.trim().split(" ");
+        console.log("ok", meta)
         if (!meta.includes("val")) return;
 
 

--- a/plugins/val-town-open-button.mjs
+++ b/plugins/val-town-open-button.mjs
@@ -52,7 +52,6 @@ export function valTownOpenButton() {
 
         // Only run on blocks marked with `val` meta
         const meta = codeBlock.meta.trim().split(" ");
-        console.log("ok", meta)
         if (!meta.includes("val")) return;
 
 

--- a/src/content/docs/guides/creating-a-webhook.mdx
+++ b/src/content/docs/guides/creating-a-webhook.mdx
@@ -5,6 +5,9 @@ description: Use Val Town to receive HTTP webhooks from services like Discord or
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
+
 A webhook is another name for a
 [Request](https://developer.mozilla.org/en-US/docs/web/api/request) that is sent
 between two services on the web. They "hook" into the events that one service
@@ -25,25 +28,7 @@ argument and return a
 Here's an example that connects the [Clerk](http://clerk.com) authentication
 service and [Discord](http://discord.com).
 
-```ts title="Discord webhook example" val
-import { discordWebhook } from "https://esm.town/v/stevekrouse/discordWebhook?v=3";
-
-// # New Val Town User (on Clerk) -> Val Town Discord notification
-// Translates one kind of webhook (Clerk) into another (Discord)
-export async function handleDiscordNewUser(req: Request) {
-  // check custom auth secret sent from clerk
-  if (req.headers.get("auth") !== Deno.env.get("clerkNonSensitive"))
-    return new Response("Unauthorized", { status: 401 });
-  const body = await req.json();
-  await discordWebhook({
-    url: Deno.env.get("newUserDiscord"),
-    content: body.data.email_addresses[0].email_address +
-      " " +
-      body.data.profile_image_url,
-  });
-  return new Response("Success");
-}
-```
+<Val url="https://www.val.town/embed/maxm/discordClerkWebhookHandlerExample" />
 
 The val above has three parts:
 

--- a/src/content/docs/guides/generate-pdfs.mdx
+++ b/src/content/docs/guides/generate-pdfs.mdx
@@ -7,42 +7,14 @@ description: >
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 You can generate PDFs using an external library like [jsPDF](https://github.com/parallax/jsPDF).
 
-```ts title="jsPDF usage example" val
-import { jsPDF } from "npm:jspdf";
-
-export const helloWorldPDF = async (req: Request) => {
-  const doc = new jsPDF();
-  doc.text("Hello world!", 10, 10);
-  return new Response(doc.output(), {
-    headers: { "Content-Type": "application/pdf" },
-  });
-};
-```
+<Val url="https://www.val.town/embed/maxm/jsPDFExample" />
 
 Here's a more comprehensive example that builds an invoice.
 
 ![Screenshot 2023-06-26 at 11.56.47.png](./generate-pdfs/screenshot_2023-06-26_at_115647.png)
 
-```ts title="Invoice generator" val
-import { generateInvoicePDF } from "https://esm.town/v/vtdocs/generateInvoicePDF?v=1";
-
-export const examplePDF = async (req: Request) => {
-  const invoicePDF = generateInvoicePDF({
-    invoiceNumber: "001",
-    date: new Date().toDateString(),
-    customerName: "Alice Bar",
-    customerEmail: "alice@bar.com",
-    items: [{ description: "Arabica Beans 500g", quantity: 2, price: 10 }, {
-      description: "Robusta Beans 500g",
-      quantity: 1,
-      price: 11,
-    }],
-    currencySymbol: "$",
-  });
-  return new Response(invoicePDF, {
-    headers: { "Content-Type": "application/pdf" },
-  });
-};
-```
+<Val url="https://www.val.town/embed/maxm/completeJSPDFExample" />

--- a/src/content/docs/guides/rss.mdx
+++ b/src/content/docs/guides/rss.mdx
@@ -5,6 +5,8 @@ description: Val Town can both parse and generate RSS feeds for blogs and other 
 lastUpdated: 2023-12-05
 ---
 
+import Val from "@components/Val.astro";
+
 Val Town can both parse and generate [RSS](https://en.wikipedia.org/wiki/RSS) feeds for blogs and other updated sources.
 
 ## Polling RSS
@@ -37,23 +39,5 @@ export async function pollRSSFeeds({ lastRunAt }: Interval) {
 
 ## Creating RSS
 
-```ts title="Creating example" val
-import { dataToRSS } from "https://esm.town/v/stevekrouse/dataToRSS";
-import { valTownBlogJSON } from "https://esm.town/v/stevekrouse/valTownBlogJSON";
+<Val url="https://www.val.town/embed/maxm/rssFeedExample" />
 
-export async function valTownBlogRSS() {
-  const json = await valTownBlogJSON();
-  return dataToRSS(
-    json.map((blog) => ({
-      title: blog.title,
-      link: blog.url,
-      pubDate: blog.date,
-    })),
-    {
-      title: "Val Town Blog",
-      link: "https://blog.val.town",
-      rssLink: "https://stevekrouse-blogrss.web.val.run/",
-    },
-  );
-}
-```

--- a/src/content/docs/guides/save-html-form-data.mdx
+++ b/src/content/docs/guides/save-html-form-data.mdx
@@ -4,6 +4,8 @@ generated: 1701279907843
 lastUpdated: 2023-12-05
 ---
 
+import Val from "@components/Val.astro";
+
 You can submit forms to Val Town using the [HTTP handler Val](/types/http) . You can
 place these forms on any page on the internet - or host the form directly on Val
 Town.
@@ -20,34 +22,7 @@ Write a val function that accepts a
 [Request](https://developer.mozilla.org/en-US/docs/web/api/request) and returns
 a [Response](https://developer.mozilla.org/en-US/docs/web/api/response).
 
-```ts title="@user/saveFormData" val
-import { blob } from "https://esm.town/v/std/blob?v=11";
-import { email } from "https://esm.town/v/std/email?v=11";
-
-export const saveFormData = async (req: Request) => {
-  // Get existing list of submitted email addresses
-  let submittedEmailAddresses = await blob.getJSON("submittedEmailAddresses") as string[];
-
-  // If there were no email addresses stored, create an empty array
-  submittedEmailAddresses ??= [];
-
-  // Pick out the form data
-  const formData = await req.formData();
-  const emailAddress = formData.get("email") as string;
-  if (submittedEmailAddresses.includes(emailAddress)) {
-    return new Response("You're already signed up!");
-  }
-
-  // Send a notification email
-  email({ text: `${emailAddress} just signed up!`, subject: "New sign up" });
-
-  // Store form data
-  submittedEmailAddresses.push(emailAddress);
-  await blob.setJSON("submittedEmailAddresses", submittedEmailAddresses);
-
-  return new Response("Thanks! You're signed up!");
-};
-```
+<Val url="https://www.val.town/embed/maxm/saveFormDataExample?v=1" />
 
 ### Add the form to your webpage
 
@@ -91,55 +66,7 @@ function) gets sent a
 You can check the HTTP method using `req.method` and change how your val
 function responds.
 
-```ts title="@user/renderFormAndSaveData" ins={5-27} val
-import { blob } from "https://esm.town/v/std/blob?v=11";
-import { email } from "https://esm.town/v/std/email?v=11";
-import { thisWebURL } from "https://esm.town/v/stevekrouse/thisWebURL?v=2";
-
-export const renderFormAndSaveData = async (req: Request) => {
-  // A visit from a web browser? Serve a HTML page with a form
-  if (req.method === "GET") {
-    return new Response(
-      `
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Email Form</title>
-</head>
-<body>
-  <form action="${thisWebURL()}" method="post">
-    <label for="email">Email:</label>
-    <input type="email" id="email" name="email" required>
-    <br>
-    <input type="submit" value="Submit">
-  </form>
-</body>
-</html>
-    `,
-      { headers: { "Content-Type": "text/html" } },
-    );
-  }
-
-  // Get existing list of submitted email addresses
-  let submittedEmailAddresses = await blob.getJSON("submittedEmailAddresses") as string[];
-
-  // If there were no email addresses stored, create an empty array
-  submittedEmailAddresses ??= [];
-
-  // Pick out the form data
-  const formData = await req.formData();
-  const emailAddress = formData.get("email") as string;
-  if (submittedEmailAddresses.includes(emailAddress)) {
-    return new Response("You're already signed up!");
-  }
-  email({ text: `${emailAddress} just signed up!`, subject: "New sign up" });
-  // Store form data
-  submittedEmailAddresses.push(emailAddress);
-  await blob.setJSON("submittedEmailAddresses", submittedEmailAddresses);
-
-  return new Response("Thanks! You're signed up!");
-};
-```
+<Val url="https://www.val.town/embed/maxm/saveFormDataExample?v=2#L5-27" />
 
 See [Web forms — Working with user data](https://developer.mozilla.org/en-US/docs/Learn/Forms)
 on the MDN Web Docs site for more help with forms. Forms are a basic part of

--- a/src/content/docs/guides/save-html-form-data.mdx
+++ b/src/content/docs/guides/save-html-form-data.mdx
@@ -66,7 +66,9 @@ function) gets sent a
 You can check the HTTP method using `req.method` and change how your val
 function responds.
 
-<Val url="https://www.val.town/embed/maxm/saveFormDataExample?v=2#L5-27" />
+{/* TODO: When we fix the scoll-to-line issue on embeded vals add "#L5-27" back to the end of this link. */}
+
+<Val url="https://www.val.town/embed/maxm/saveFormDataExample?v=2" />
 
 See [Web forms — Working with user data](https://developer.mozilla.org/en-US/docs/Learn/Forms)
 on the MDN Web Docs site for more help with forms. Forms are a basic part of

--- a/src/content/docs/integrations/Discord/how-to-make-a-discord-bot-hosted-24-7-for-free-in-.mdx
+++ b/src/content/docs/integrations/Discord/how-to-make-a-discord-bot-hosted-24-7-for-free-in-.mdx
@@ -5,6 +5,8 @@ description: How to make a Discord bot hosted 24/7 for free in 6 steps
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 ![https://i.postimg.cc/bw5Xj8Rd/ping.gif](https://i.postimg.cc/bw5Xj8Rd/ping.gif)
 
 ## Introduction
@@ -123,43 +125,7 @@ export const registerDiscordCommand = result.json();
 
 1. Press **Run** to listen for Slash Commands and reply.
 
-```ts title="Discord interaction handler" val
-import { verify_discord_signature } from "https://esm.town/v/mattx/verify_discord_signature?v=8";
-
-export const handleDiscordInteraction = async (req: Request) => {
-  if (req.method === "GET") return new Response();
-  const body = await req.json();
-  const verified = await verify_discord_signature(
-    Deno.env.get('discordPublicKey'),
-    JSON.stringify(body),
-    req.headers.get("X-Signature-Ed25519"),
-    req.headers.get("X-Signature-Timestamp"),
-  );
-  if (!verified)
-    return new Response("signature invalid", {
-      status: 401,
-      statusText: "signature invalid",
-    });
-  // PING
-  if (body.type === 1)
-    return Response.json({ type: 1 }); // PONG
-  // APPLICATION_COMMAND interactions
-  if (body.type === 2) {
-    if (body.data?.name === "ping")
-      return Response.json({
-        type: 4,
-        data: {
-          content: `Pong! It is ${new Date()}`,
-        },
-      });
-    return new Response("Bad request", {
-      status: 400,
-      statusText: "Bad request",
-    });
-  }
-  return new Response("Not handled", { status: 422 });
-};
-```
+<Val url="https://www.val.town/embed/maxm/discordBotExample" />
 
 2. Next to your val's name, click 🔒 > **Unlisted.**
 3. In the val above, in the bottom-left corner of the val, click **Script** and change it to **HTTP.**

--- a/src/content/docs/integrations/Discord/send-message.mdx
+++ b/src/content/docs/integrations/Discord/send-message.mdx
@@ -6,6 +6,8 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 1. Create a Discord webhook
 2. Add the webhook to your [Val Town environment variables](https://www.val.town/settings/environment-variables)
 3. Use `@stevekrouse.discordWebhook` to send the message
@@ -39,23 +41,4 @@ You can [browse example usages of this function here](https://www.val.town/v/ste
 
 ![Untitled](./send-discord-message-via-webhook/untitled-1.png)
 
-```ts title="Integration example" val
-import { discordWebhook } from "https://esm.town/v/stevekrouse/discordWebhook?v=3";
-
-// # New Val Town User (on Clerk) -> Val Town Discord notification
-// Translates one kind of webhook (Clerk) into another (Discord)
-export async function handleDiscordNewUser(req: Request) {
-  // check custom auth secret sent from clerk
-  if (req.headers.get("auth") !== Deno.env.get("clerkNonSensitive"))
-    return new Response("Unauthorized", { status: 401 });
-  const body = await req.json();
-  await discordWebhook({
-    url: Deno.env.get("newUserDiscord"),
-    content:
-      body.data.email_addresses[0].email_address +
-      " " +
-      body.data.profile_image_url,
-  });
-  return new Response("Success");
-}
-```
+<Val url="https://www.val.town/embed/maxm/discordClerkWebhookHandlerExample" />

--- a/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
+++ b/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
@@ -4,6 +4,8 @@ generated: 1701279907831
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 GitHub supports sending webhooks for a
 [number of events](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads).
 In this example, you'll use `console.email` to receive an email when someone
@@ -12,17 +14,7 @@ stars your GitHub repository.
 First, create an Web API handler function val to receive star webhooks from
 GitHub, or use this one:
 
-```ts title="GitHub star webhook" val
-import { email } from "https://esm.town/v/std/email?v=11";
-
-export const githubStarWebhook = async (req: Request) => {
-  const { action, sender, repository } = await req.json();
-  if (action === "created") {
-    email({ text: `Repository ${repository.full_name} starred by ${sender.login}` });
-  }
-  return new Response("OK", { status: 200 });
-};
-```
+<Val url="https://www.val.town/embed/maxm/githubStarWebhookExample" />
 
 Go to the **Webhooks** tab in your GitHub repository's settings.
 
@@ -69,44 +61,10 @@ signature is sent as a header: `x-hub-signature-256`.
 
 With your secret, the payload, and the signature header, you can use Octokit's
 [verify](https://github.com/octokit/webhooks.js/#webhooksverify) function to
-confirm that the webhook came from GitHub. Here's a val that does that for you:
+confirm that the webhook came from GitHub. Here's how you would integrate that into the original example:
 
-```ts title="@vtdocs/verifyGithubWebhookSignature" val
-export const verifyGithubWebhookSignature = async (
-  secret: string,
-  payload: string,
-  signatureHeader: string,
-) => {
-  const { verify } = await import(
-    "https://esm.sh/@octokit/webhooks-methods@3.0.2?pin=v106"
-  );
-  return await verify(secret, payload, signatureHeader) === true;
-};
-```
 
-It can be integrated into the original example like this:
-
-```ts title="Improved GitHub star webhook" val
-import { email } from "https://esm.town/v/std/email?v=11";
-import { verifyGithubWebhookSignature } from "https://esm.town/v/vtdocs/verifyGithubWebhookSignature?v=2";
-
-export const githubWebhookWithVerify = async (req: Request) => {
-  const payload = await req.json();
-  const verified = await verifyGithubWebhookSignature(
-    Deno.env.get("githubWebhookToken"),
-    JSON.stringify(payload),
-    req.headers.get("X-Hub-Signature-256"),
-  );
-  if (!verified) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-  const { action, sender, repository } = payload;
-  if (action === "created") {
-    email({ text: `Repository ${repository.full_name} starred by ${sender.login}` });
-  }
-  return new Response("OK", { status: 200 });
-};
-```
+<Val url="https://www.val.town/embed/maxm/verifiedGithubStarWebhookExample" />
 
 With your webhook pointing to the new example, your val now refuses payload that
 don't come from GitHub!

--- a/src/content/docs/integrations/Slack/bot.mdx
+++ b/src/content/docs/integrations/Slack/bot.mdx
@@ -5,6 +5,8 @@ description: Create a Slack bot that replies to mentions
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 You can build a Slack bot using vals.
 
 Vals can receive events from Slack's
@@ -44,42 +46,9 @@ verify the endpoint is correct.
 Run this val that responds to the challenge, and replies to `app_mention`
 events.
 
-```ts title="Reply to message" val
-import { fetchJSON } from "https://esm.town/v/stevekrouse/fetchJSON?v=41";
 
-export const slackReplyToMessage = async (req: Request) => {
-  const body = await req.json();
-  // Verify the request is genuine
-  if (body.token !== Deno.env.get("slackVerificationToken")) {
-    return new Response(undefined, { status: 401 });
-  }
-  // Respond to the initial challenge (when events are enabled)
-  if (body.challenge) {
-    return Response.json({ challenge: body.challenge });
-  }
-  // Reply to app_mention events
-  if (body.event.type === "app_mention") {
-    // Note: `body.event` has information about the event
-    // like the sender and the message text
-    const result = await fetchJSON(
-      "https://slack.com/api/chat.postMessage",
-      {
-        headers: {
-          "Authorization": `Bearer ${Deno.env.get("slackToken")}`,
-        },
-        method: "POST",
-        body: JSON.stringify({
-          channel: body.event.channel,
-          thread_ts: body.event.ts,
-          text: "Hello, ~World~ from Val Town!",
-        }),
-      },
-    );
-    // Slack replies with information about the created message
-    console.log(result);
-  }
-};
-```
+<Val url="https://www.val.town/embed/maxm/slackBotExample" />
+
 
 ## 4. Set up event subscriptions
 

--- a/src/content/docs/integrations/telegram.mdx
+++ b/src/content/docs/integrations/telegram.mdx
@@ -7,6 +7,9 @@ description: |
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
+
 You can create Telegram bots using vals.
 
 In this example, you'll create a val that uses the [HTTP Val](/types/http) to
@@ -50,28 +53,8 @@ came from our bot.
 
 Copy this val that uses the [HTTP Val](/types/http) :
 
-```ts title="Webhook handler" val
-import { telegramSendMessage } from "https://esm.town/v/vtdocs/telegramSendMessage?v=5";
+<Val url="https://www.val.town/embed/maxm/telegramWebhookExample" />
 
-export const telegramWebhookEchoMessage = async (req: Request) => {
-  // Verify this webhook came from our bot
-  if (
-    req.headers.get("x-telegram-bot-api-secret-token") !==
-      Deno.env.get("telegramWebhookSecret")
-  ) {
-    return new Response(undefined, { status: 401 });
-  }
-  // Echo back the user's message
-  const body = await req.json();
-  const text: string = body.message.text;
-  const chatId: number = body.message.chat.id;
-  await telegramSendMessage(
-    Deno.env.get("telegramBotToken"),
-    { chat_id: chatId, text },
-  );
-  return Response.json("ok");
-};
-```
 
 ### Tell your bot about the webhook handler
 

--- a/src/content/docs/types/email.mdx
+++ b/src/content/docs/types/email.mdx
@@ -6,6 +6,8 @@ sidebar:
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
+
 Email handler vals get their own email address that you can send email
 to, and when Val Town receives that email, it triggers the val with the email
 as its first argument. Ever wanted a robot that you could forward emails to,
@@ -22,9 +24,9 @@ Email handlers receive an argument called `Email` and can do anything with it:
 they can go on to reply to the email with the [standard library](/std/email),
 or call methods in response to it.
 
-```ts title="Example" val
+```ts title="Example"
 export function emailHandler(email: Email) {
-  console.log("Email received!");
+  console.log("Email received!", email.from, email.subject, email.text);
 }
 ```
 
@@ -42,28 +44,9 @@ interface Email {
 
 ## Example
 
-```ts title="Save received emails" val
-import { blob } from "https://esm.town/v/std/blob";
-import { email } from "https://esm.town/v/std/email";
+**Save received emails**
 
-export async function testEmail2(e: {
-  from: string;
-  to: string[];
-  subject: string;
-  text: string;
-  html: string;
-}) {
-  const testEmails = await blob.getJSON("testEmails") as [];
-  await blob.setJSON("testEmails", [...testEmails, {
-    ...e,
-    from: "~redacted~",
-  }]);
-  return email({
-    text: JSON.stringify(e),
-    subject: "Emailed received at @stevekrouse.testEmail2!",
-  });
-}
-```
+<Val url="https://www.val.town/embed/maxm/emailExample" />
 
 The email address for a val `@user.testEmail` would be `user.testEmail@valtown.email`. Note that the username does not contain
 a leading `@` and that the email domain is `valtown.email`.

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -8,6 +8,9 @@ sidebar:
 lastUpdated: 2024-01-31
 ---
 
+import Val from "@components/Val.astro";
+
+
 Val Town supports asynchronous functions with the basic primitives
 of [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
 in JavaScript. All kinds of handler vals, including HTTP, Email,
@@ -29,18 +32,7 @@ and then logs the word "Hi!". You can use the same structure
 to schedule time-consuming work like database queries
 or network traffic till after the Val's response is already sent.
 
-```ts title="Unawaited async function" val
-export async function handle() {
-  // Schedule work to do later
-  (async () => {
-    // Wait 1 second
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    // Log a message
-    console.log("Hi!");
-  })();
-  return Response.json({ ok: true });
-}
-```
+<Val url="https://www.val.town/embed/maxm/unawaitedAsyncExample" />
 
 The key to both techniques is that the async work does
 _not_ use the `await` keyword, so JavaScript does not wait

--- a/src/content/docs/types/http/index.mdx
+++ b/src/content/docs/types/http/index.mdx
@@ -8,6 +8,7 @@ sidebar:
 lastUpdated: 2023-12-22
 ---
 
+import Val from "@components/Val.astro";
 import { LinkCard } from "@astrojs/starlight/components";
 
 HTTP Vals let you expose an API or website from your val.
@@ -22,11 +23,7 @@ These handlers need to export a function that takes a `Request` object
 as the first parameter and returns a `Response` object. The function
 can be asynchronous.
 
-```ts title="Example" val
-export function handler(request: Request) {
-  return Response.json({ ok: true });
-}
-```
+<Val url="https://www.val.town/embed/maxm/exampleHTTP" />
 
 <LinkCard title="Basic examples" href="/types/http/basic-examples" />
 

--- a/src/content/docs/types/http/jsx.mdx
+++ b/src/content/docs/types/http/jsx.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 2
 ---
 
+import Val from "@components/Val.astro";
+
 Val Town supports server-rendered [JSX](https://en.wikipedia.org/wiki/JSX_%28JavaScript%29). This lets you use JSX syntax to construct
 your HTML string. It does not include any client-side JSX framework features,
 such as re-rendering on the client, but you can string that together yourself
@@ -28,75 +30,23 @@ A good default is [Preact](https://github.com/preactjs/preact), which provides a
 nice `preact-render-to-string` module that lets you quickly turn that JSX object
 into a string that you can use for a response.
 
-```ts title="Preact example" val
-/** @jsxImportSource https://esm.sh/preact */
-import { render } from "npm:preact-render-to-string";
-
-export const preactExample = () =>
-  new Response(render(<div>Test {1 + 1}</div>), {
-    headers: {
-      "Content-Type": "text/html",
-    },
-  });
-```
+<Val url="https://www.val.town/embed/maxm/preactExample" />
 
 ### React
 
-```ts title="React example" val
-/** @jsxImportSource https://esm.sh/react */
-import { renderToString } from "npm:react-dom/server";
-
-export const reactExample = () =>
-  new Response(renderToString(<div>Test {1 + 1}</div>), {
-    headers: {
-      "Content-Type": "text/html",
-    },
-  });
-```
+<Val url="https://www.val.town/embed/maxm/reactExample" />
 
 ### Vue
 
-```ts title="Vue example" val
-/** @jsxImportSource https://esm.sh/vue */
-import { renderToString } from "npm:vue/server-renderer";
-
-export const vueExample = async () =>
-  new Response(await renderToString(<div>Test {1 + 1}</div>), {
-    headers: {
-      "Content-Type": "text/html",
-    },
-  });
-```
+<Val url="https://www.val.town/embed/maxm/vueExample" />
 
 ### Solid
 
-```ts title="Solid example" val
-/** @jsxImportSource https://esm.sh/solid-jsx */
-import { renderToString } from "npm:solid-js/web";
-
-export const solidExample = async () =>
-  new Response(await renderToString(() => <div>Test {1 + 1}</div>), {
-    headers: {
-      "Content-Type": "text/html",
-    },
-  });
-```
+<Val url="https://www.val.town/embed/maxm/solidExample" />
 
 ### Hono
 
-```ts title="Hono example" val
-/** @jsxImportSource npm:hono@3/jsx */
-
-export const honoExample = () => {
-  const jsx = <div>Test {1 + 1}</div>;
-
-  return new Response(jsx.toString(), {
-    headers: {
-      "Content-Type": "text/html",
-    },
-  });
-};
-```
+<Val url="https://www.val.town/embed/maxm/honoJSXExample" />
 
 :::tip[Interoperability]
 

--- a/src/content/docs/types/http/routing.mdx
+++ b/src/content/docs/types/http/routing.mdx
@@ -6,6 +6,8 @@ sidebar:
   order: 3
 ---
 
+import Val from "@components/Val.astro";
+
 One of the coolest things about the Request/Response API is that it works with modern web frameworks, so you can use routing and their helper methods! When an
 HTTP val is deployed, it is available at a subdomain like
 `handle-valname.web.val.run`, and requests to any subdirectory
@@ -15,93 +17,31 @@ or path will be routed to the val.
 
 Here's an example with [Hono](https://hono.dev/):
 
-```ts title="Hono example" val
-import { Hono } from "npm:hono@3";
-
-const app = new Hono();
-app.get("/", (c) => c.text("Hello world!"));
-app.get("/yeah", (c) => c.text("Routing!"));
-export default app.fetch;
-```
+<Val url="https://www.val.town/embed/maxm/honoExample" />
 
 ### Peko
 
 And one with [Peko](https://peko.deno.dev/):
 
-```ts title="Peko example" val
-import { Peko } from "https://deno.land/x/peko@2.0.0/mod.ts";
-
-export const pekoExample = async (request) => {
-  const server = new Peko.Router();
-  server.get("/", () => new Response("Yes? There's something at /hello"));
-  server.get("/hello", () => new Response("Hello world!"));
-  return server.requestHandler(request);
-};
-```
+<Val url="https://www.val.town/embed/maxm/pekoExample" />
 
 ### nhttp
 
 And [nhttp](https://github.com/nhttp/nhttp):
 
-```ts title="NHttp example" val
-import { nhttp } from "npm:nhttp-land@1";
-
-export const nhttpExample = async (request) => {
-  const app = nhttp();
-  app.get("/", () => {
-    return "Hello, World";
-  });
-  app.get("/cat", () => {
-    return { name: "cat" };
-  });
-  return app.handleRequest(request);
-};
-```
+<Val url="https://www.val.town/embed/maxm/nhttpExample" />
 
 ### itty-router
 
 A super tiny example with [itty-router](https://itty.dev/itty-router):
 
-
-```ts title="Itty example" val
-import { Router, json } from "npm:itty-router@4";
-
-export const ittyRouterExample = async (request: Request) => {
-  const router = Router();
-  router.get("/", () => "Hi");
-  return router.handle(request).then(json);
-};
-```
+<Val url="https://www.val.town/embed/maxm/ittyExample" />
 
 ### feTS
 
 A simple example of using [feTS server](https://the-guild.dev/openapi/fets/server/quick-start):
 
-```ts title="@user/fetsServer" val
-import { createRouter, Response } from "npm:fets";
-
-export const router = createRouter().route({
-  method: "GET",
-  path: "/greetings",
-  schemas: {
-    responses: {
-      200: {
-        type: "object",
-        properties: {
-          message: {
-            type: "string",
-          },
-        },
-        required: ["message"],
-        additionalProperties: false,
-      },
-    },
-  },
-  handler: () => Response.json({ message: "Hello World!" }),
-});
-
-export default router.fetch;
-```
+<Val url="https://www.val.town/embed/maxm/fetsServerExample" />
 
 Notice, that it exports the `router`, which allows to use the [feTS client](https://the-guild.dev/openapi/fets/client/quick-start) to make routes type safe:
 
@@ -117,4 +57,4 @@ const client = createClient<typeof router>({
 const response = await client["/greetings"].get();
 const greetings = await response.json();
 console.log(greetings);
-```
+``` 

--- a/src/content/docs/types/script.md
+++ b/src/content/docs/types/script.md
@@ -14,7 +14,7 @@ It's common to use script vals to write standalone functions that can
 be imported by your HTTP, Scheduled, and Email vals. A script val
 can be as simple as a function that just adds two numbers:
 
-```tsx
+```tsx val
 export function add(a: number, b: number) {
   return a + b;
 }


### PR DESCRIPTION
The changes are here:

- https://replace-http-code-block-exam.val-town-docs.pages.dev/guides/creating-a-webhook/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/guides/generate-pdfs/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/guides/save-html-form-data/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/integrations/discord/how-to-make-a-discord-bot-hosted-24-7-for-free-in-/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/integrations/discord/send-message/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/integrations/github/receiving-a-github-webhook/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/integrations/slack/bot/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/integrations/telegram/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/email/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/http/early-return/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/http/index/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/http/jsx/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/http/routing/
- https://replace-http-code-block-exam.val-town-docs.pages.dev/types/script/