### PR TITLE
Add 'Powered by [SaaS Custom Domains](https://saascustomdomains.com)' footer to custom-domains docs.

### DIFF
--- a/src/content/docs/reference/custom-domains.md
+++ b/src/content/docs/reference/custom-domains.md
@@ -63,3 +63,7 @@ Create the following two A records:
 | `example.com` | `99.83.186.151` |
 
 Replace `example.com` with your domain. In some domain platforms, you should replace `example.com` with `@`.
+
+<hr>
+
+Val Town custom domains are powered by [SaaS Custom Domains](https://saascustomdomains.com).


### PR DESCRIPTION
# Why?

Val Town uses [SaaS Custom Domains](https://saascustomdomains.com) to power custom domains.
<img width="1440" alt="Screen Shot 2024-04-08 at 21 29 24" src="https://github.com/val-town/val-town-docs/assets/31215048/b61a4422-df9c-4c1b-9a72-e0e47b0d30f1">
