### PR TITLE
Consistent naming of val types VAL-19716

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -7,3 +7,4 @@
 /tips /
 /demo https://www.youtube.com/watch?v=V6qT5aA_UM4
 /types/web /types/http
+/types/scheduled /types/cron

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -62,8 +62,8 @@ export default defineConfig({
               collapsed: true,
             },
             {
-              label: "Scheduled",
-              link: "types/scheduled",
+              label: "Cron",
+              link: "types/cron",
             },
             {
               label: "Email",

--- a/src/content/docs/guides/rss.mdx
+++ b/src/content/docs/guides/rss.mdx
@@ -11,7 +11,7 @@ Val Town can both parse and generate [RSS](https://en.wikipedia.org/wiki/RSS) fe
 
 ## Polling RSS
 
-You would run this example in val town as a [Scheduled val](/types/scheduled)
+You would run this example in val town as a [Cron val](/types/cron)
 that ran on a regular interval, and it would check a blog's feed every 15 minutes.
 
 ```ts title="Polling example" val

--- a/src/content/docs/guides/save-html-form-data.mdx
+++ b/src/content/docs/guides/save-html-form-data.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2023-12-05
 
 import Val from "@components/Val.astro";
 
-You can submit forms to Val Town using the [HTTP handler Val](/types/http) . You can
+You can submit forms to Val Town using the [HTTP val](/types/http). You can
 place these forms on any page on the internet - or host the form directly on Val
 Town.
 
@@ -16,7 +16,7 @@ notification for each new signup.
 
 ## Add a form to your website
 
-### Create a val that uses the [HTTP handler Val](/types/http)
+### Create an [HTTP val](/types/http)
 
 Write a val function that accepts a
 [Request](https://developer.mozilla.org/en-US/docs/web/api/request) and returns

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -17,7 +17,7 @@ and persist data — all from the browser and instantly deployed.
 - There are different kinds of vals:
   - **Script** [↗](/types/script) - freeform, run manually, for one-off operations or testing
   - **HTTP** [↗](/types/http) - expose an API endpoint, make a website, or accept webhooks
-  - **Scheduled** [↗](/types/scheduled) - trigger code on a timer or cron schedule
+  - **Cron** [↗](/types/cron) - trigger code on a timer or cron schedule
   - **Email** [↗](/types/email) - trigger code on an incoming email
 - **The Val Town Standard Library** provides a set of useful services:
   - **Blob Storage** [↗](/std/blob) - store and retrieve any data

--- a/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
+++ b/src/content/docs/integrations/GitHub/receiving-a-github-webhook.mdx
@@ -11,7 +11,7 @@ GitHub supports sending webhooks for a
 In this example, you'll use `console.email` to receive an email when someone
 stars your GitHub repository.
 
-First, create an Web API handler function val to receive star webhooks from
+First, create an HTTP val to receive star webhooks from
 GitHub, or use this one:
 
 <Val url="https://www.val.town/embed/maxm/githubStarWebhookExample" />

--- a/src/content/docs/quickstarts/first-cron.mdx
+++ b/src/content/docs/quickstarts/first-cron.mdx
@@ -16,9 +16,9 @@ If you get stuck, please ask for help in the [Val Town Discord](https://discord.
 The email you sign up with will be the one that receives the weather emails.
 :::
 
-### Step 2: Create a Scheduled/Cron val
+### Step 2: Create a Cron val
 
-In the top-right corner of Val Town, click **New** > **Scheduled function**.
+In the top-right corner of Val Town, click **New** > **Cron**.
 
 This will create an schedule a new empty val in your account that looks like this:
 

--- a/src/content/docs/reference/environment-variables.mdx
+++ b/src/content/docs/reference/environment-variables.mdx
@@ -51,4 +51,4 @@ For example, in this public script val, you can see that I'm using a discord bot
   height="180px"
 />
 
-If you expose an HTTP API or email handler val, those vals can be _triggered_ by anyone who knows their URL or email address, but they still can't access your environment variables. This is how server-side code normally works. If someone wants to run your code with _their_ environment variables, they need to _import_ your code and run it in their own vals.
+If you expose an HTTP or email val, those vals can be _triggered_ by anyone who knows their URL or email address, but they still can't access your environment variables. This is how server-side code normally works. If someone wants to run your code with _their_ environment variables, they need to _import_ your code and run it in their own vals.

--- a/src/content/docs/troubleshooting/exports.md
+++ b/src/content/docs/troubleshooting/exports.md
@@ -1,11 +1,11 @@
 ---
 title: Exports
 description: |
-  Vals with triggers (HTTP, Scheduled, Email) require at least one export.
+  Vals with triggers (HTTP, Cron, Email) require at least one export.
 lastUpdated: 2024-05-09
 ---
 
-Vals with triggers (HTTP, Scheduled, Email) require at least one export: the function to run when that val is triggered. If your val has multiple exports, then we require one of them to the `default` export, which will be the function that runs when the val is triggered.
+Vals with triggers (HTTP, Cron, Email) require at least one export: the function to run when that val is triggered. If your val has multiple exports, then we require one of them to the `default` export, which will be the function that runs when the val is triggered.
 
 Script vals can export anything or nothing.
 

--- a/src/content/docs/types/cron.mdx
+++ b/src/content/docs/types/cron.mdx
@@ -1,5 +1,5 @@
 ---
-title: Scheduled (Cron)
+title: Cron (Scheduled)
 sidebar:
   order: 1
 description: Schedules let code on Val Town run every day, every hour, or
@@ -13,20 +13,20 @@ You can schedule code to run repeatedly on Val Town. Want to check an RSS
 feed every hour, or send a reminder email every day? This is how to do it:
 just create a scheduled function and specify when it should run.
 
-- Scheduled functions can be configured with [cron syntax](https://en.wikipedia.org/wiki/Cron), or simple intervals like "once an hour"
+- Cron functions can be configured with [cron syntax](https://en.wikipedia.org/wiki/Cron), or simple intervals like "once an hour"
 - Functions can run up to once every 15 minutes, or [once a minute, with the Pro plan](https://www.val.town/pricing).
 
 ## Type Signature
 
-Scheduled functions should take an `Interval` object as a parameter, and can return anything as a result. The return value is ignored.
+Cron functions should take an `Interval` object as a parameter, and can return anything as a result. The return value is ignored.
 
 ```tsx title="Example" val
-export function intervalHandler(interval: Interval) {
-  console.log("Interval ran!");
+export function cronValHandler(interval: Interval) {
+  console.log("Cron val ran!");
 }
 ```
 
-The interval type has the following shape:
+The Interval type has the following shape:
 
 ```ts
 interface Interval {

--- a/src/content/docs/types/email.mdx
+++ b/src/content/docs/types/email.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2024-05-09
 
 import Val from "@components/Val.astro";
 
-Email handler vals get their own email address that you can send email
+Email vals get their own email address that you can send email
 to. When Val Town receives that email, it triggers the val with the email
 as its first argument.
 
@@ -18,10 +18,10 @@ Vals can send email, too! Using the [email function in the standard library](/st
 
 ## Type Signature
 
-Email handlers receive an argument called `Email` that represents the email that was sent to the val. Here's an example of an email handler:
+Email vals receive an argument called `Email` that represents the email that was sent to the val. Here's an example of an email val:
 
 ```ts title="Example"
-export function emailHandler(email: Email) {
+export function emailValHandler(email: Email) {
   console.log("Email received!", email.from, email.subject, email.text);
 }
 ```
@@ -48,6 +48,6 @@ This val forwards any email it receives to me. Try it out by sending an email to
 
 :::note[Attachements not supported]
 
-Email handler vals do not support attachments. If they receive an email with an attachment, the attachment will be stripped. If this is something you want, please [upvote the feature request](https://github.com/val-town/val-town-product/discussions/75) to support attachments in email handler vals.
+Email vals do not support attachments. If they receive an email with an attachment, the attachment will be stripped. If this is something you want, please [upvote the feature request](https://github.com/val-town/val-town-product/discussions/75) to support attachments in email vals.
 
 :::

--- a/src/content/docs/types/http/early-return.mdx
+++ b/src/content/docs/types/http/early-return.mdx
@@ -2,7 +2,7 @@
 title: Deferred functions
 description: |
   You can do asynchronous work after return a response from
-  an HTTP handler.
+  an HTTP val.
 sidebar:
   order: 5
 lastUpdated: 2024-01-31
@@ -14,7 +14,7 @@ import Val from "@components/Val.astro";
 Val Town supports asynchronous functions with the basic primitives
 of [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
 in JavaScript. All kinds of handler vals, including HTTP, Email,
-and Interval, can be async functions: if they return a Promise,
+and Cron, can be async functions: if they return a Promise,
 we await it.
 
 We also wait until other, non-awaited asynchronous work is done

--- a/src/content/docs/types/script.md
+++ b/src/content/docs/types/script.md
@@ -11,7 +11,7 @@ Script vals are free form JavaScript, TypeScript, or JSX. They are useful
 for testing, saving utility functions, and one-off operations.
 
 It's common to use script vals to write standalone functions that can
-be imported by your HTTP, Scheduled, and Email vals. A script val
+be imported by your HTTP, Cron, and Email vals. A script val
 can be as simple as a function that just adds two numbers:
 
 ```tsx val

--- a/src/content/docs/upgrading/upgrade-to-deno.md
+++ b/src/content/docs/upgrading/upgrade-to-deno.md
@@ -29,7 +29,7 @@ that will no longer work in the new runtime.
 
 ### `setInterval` has been removed
 
-Use Scheduled Vals instead.
+Use Cron Vals instead.
 
 ### `setTimeout` has been removed
 
@@ -81,14 +81,14 @@ magic. Now the Express fields behave the way the Express docs say they do.
 
 ## Non-breaking changes
 
-### Interval evaluations has `0` arguments where it used to have `1`
+### Cron evaluations has `0` arguments where it used to have `1`
 
 On your [intervals page](https://www.val.town/settings/intervals), you may
-notice that where it used to say that intervals have `1` argument (circled below
+notice that where it used to say that crons have `1` argument (circled below
 in red), it now says they take `0` arguments (circled below in purple). This
-does not affect that fact that intervals pass the `Interval` object to the
+does not affect that fact that crons pass the `Interval` object to the
 function that has been scheduled, which allows you to get the `lastRunAt` value
-of the interval in your schedule vals.
+of the interval in your cron vals.
 
 ![Screenshot 2023-03-14 at 2.27.48 PM.png](./upgrade-to-deno/screenshot_2023-03-14_at_22748_pm.png)
 


### PR DESCRIPTION
Mostly renaming "interval" to "cron" and dropping the word "handler" from val types.

One URL change: /types/scheduled to /types/cron, for which I added a redirect.