### PR TITLE
Add openapi docs

### DIFF
--- a/public/openapi.html
+++ b/public/openapi.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Val Town API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <style>
+      :root {
+        --scalar-font: "IBM Plex Sans", sans-serif;
+        --scalar-custom-header-height: 50px;
+      }
+      header.custom-header {
+        height: var(--scalar-custom-header-height);
+        background-color: var(--scalar-background-1);
+        box-shadow: inset 0 -1px 0 var(--scalar-border-color);
+        color: var(--scalar-color-1);
+        font-size: var(--scalar-font-size-2);
+        padding: 0 18px;
+        position: sticky;
+        justify-content: space-between;
+        top: 0;
+        z-index: 100;
+      }
+      .custom-header,
+      .custom-header nav {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+      }
+      .custom-header a:hover {
+        color: var(--scalar-color-2);
+      }
+    </style>
+    <header class="custom-header">
+      <b>Val Town</b>
+      <nav>
+        <a href="https://docs.val.town/">Docs</a>
+      </nav>
+    </header>
+    <script id="api-reference" data-url="./openapi.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,3028 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Val Town API",
+    "description": "Val Town’s public API\n\nOpenAPI JSON endpoint:\n\nhttp://localhost:3001/openapi.json",
+    "termsOfService": "https://www.val.town/termsofuse",
+    "version": "1"
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Endpoints that support authorization expect Bearer authentication, using an API token provided from Val Town."
+      }
+    },
+    "schemas": {
+      "User": {
+        "description": "User object",
+        "examples": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "bio": "Hello world",
+            "username": "tmcw",
+            "profileImageUrl": null
+          }
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "bio": {
+            "anyOf": [
+              {
+                "description": "The user’s biography, if they have provided one",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "username": {
+            "anyOf": [
+              {
+                "description": "The user’s handle that they chose for themselves. Does not include the @ symbol",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "profileImageUrl": {
+            "anyOf": [
+              {
+                "description": "URL that points to the user’s profile image, if one exists",
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "bio",
+          "username",
+          "profileImageUrl"
+        ]
+      },
+      "ResultSet": {
+        "title": "ResultSet",
+        "description": "Result of executing an SQL statement.",
+        "type": "object",
+        "properties": {
+          "columns": {
+            "description": "Names of columns.\n\nNames of columns can be defined using the `AS` keyword in SQL:\n\n```sql\nSELECT author AS author, COUNT(*) AS count FROM books GROUP BY author\n```",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "columnTypes": {
+            "description": "Types of columns.\n\nThe types are currently shown for types declared in a SQL table. For column types of function calls, for example, an empty string is returned.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rows": {
+            "description": "Rows produced by the statement.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "description": "Columns can be accessed like an object by column names."
+              }
+            }
+          },
+          "rowsAffected": {
+            "description": "Number of rows that were affected by an UPDATE, INSERT or DELETE operation.\n\nThis value is not specified for other SQL statements.",
+            "type": "number"
+          },
+          "lastInsertRowid": {
+            "description": "ROWID of the last inserted row.\n\nThis value is not specified if the SQL statement was not an INSERT or if the table was not a ROWID table.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "columns",
+          "columnTypes",
+          "rows",
+          "rowsAffected"
+        ]
+      },
+      "ExtendedVal": {
+        "description": "A Val",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of this val",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "description": "This val’s id",
+            "type": "string"
+          },
+          "version": {
+            "minimum": 0,
+            "description": "The version of this val, starting at zero",
+            "type": "integer"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "description": "TypeScript code associated with this val",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "public": {
+            "description": "Whether this val is available publicly on Val Town",
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "privacy": {
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted",
+              "private"
+            ],
+            "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "interval",
+              "http",
+              "express",
+              "email",
+              "script",
+              "rpc"
+            ]
+          },
+          "author": {
+            "anyOf": [
+              {
+                "description": "The user who created this val",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "username": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "username"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "likeCount": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "referenceCount": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "readme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "version",
+          "code",
+          "public",
+          "createdAt",
+          "privacy",
+          "type",
+          "author",
+          "likeCount",
+          "referenceCount",
+          "readme"
+        ]
+      },
+      "BasicVal": {
+        "description": "A Val",
+        "examples": [
+          {
+            "version": 0,
+            "name": "counter",
+            "code": "export const count = 1;",
+            "createdAt": "2024-06-11T22:05:12.585Z",
+            "public": true,
+            "id": "00000000-0000-0000-0000-000000000000",
+            "privacy": "public",
+            "type": "script",
+            "author": {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "username": "tmcw"
+            }
+          }
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of this val",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "description": "This val’s id",
+            "type": "string"
+          },
+          "version": {
+            "minimum": 0,
+            "description": "The version of this val, starting at zero",
+            "type": "integer"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "description": "TypeScript code associated with this val",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "public": {
+            "description": "Whether this val is available publicly on Val Town",
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "privacy": {
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted",
+              "private"
+            ],
+            "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "interval",
+              "http",
+              "express",
+              "email",
+              "script",
+              "rpc"
+            ]
+          },
+          "author": {
+            "anyOf": [
+              {
+                "description": "The user who created this val",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "username": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "username"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "version",
+          "code",
+          "public",
+          "createdAt",
+          "privacy",
+          "type",
+          "author"
+        ]
+      },
+      "PaginationLinks": {
+        "description": "Links to use for pagination",
+        "type": "object",
+        "properties": {
+          "self": {
+            "format": "uri",
+            "description": "URL of this page",
+            "type": "string"
+          },
+          "prev": {
+            "format": "uri",
+            "description": "URL of the previous page, if any",
+            "type": "string"
+          },
+          "next": {
+            "format": "uri",
+            "description": "URL of the next page, if any",
+            "type": "string"
+          }
+        },
+        "required": [
+          "self"
+        ]
+      }
+    }
+  },
+  "paths": {
+    "/v1/search/vals": {
+      "get": {
+        "operationId": "searchVals",
+        "tags": [
+          "search"
+        ],
+        "description": "Search for vals across the platform",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "minLength": 1,
+              "maxLength": 512,
+              "type": "string"
+            },
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "description": "Search query"
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "semantic"
+                  ]
+                }
+              ]
+            },
+            "in": "query",
+            "name": "searchType",
+            "required": false,
+            "description": "Choose between exact search, which is substring-based, and semantic search, which uses AI embeddings"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BasicVal"
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/alias/{username}": {
+      "get": {
+        "operationId": "aliasUsername",
+        "tags": [
+          "alias"
+        ],
+        "description": "Get basic details about a user, given their username",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "description": "Username of the user who you are looking for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/alias/{username}/{val_name}": {
+      "get": {
+        "operationId": "aliasVal",
+        "tags": [
+          "alias"
+        ],
+        "description": "Get a val",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "description": "Username of the user whose val you are looking for"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_name",
+            "required": true,
+            "description": "Name of the val you’re looking for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Val",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A Val",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "The name of this val",
+                      "type": "string"
+                    },
+                    "id": {
+                      "format": "uuid",
+                      "description": "This val’s id",
+                      "type": "string"
+                    },
+                    "version": {
+                      "minimum": 0,
+                      "description": "The version of this val, starting at zero",
+                      "type": "integer"
+                    },
+                    "code": {
+                      "anyOf": [
+                        {
+                          "description": "TypeScript code associated with this val",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "public": {
+                      "description": "Whether this val is available publicly on Val Town",
+                      "type": "boolean"
+                    },
+                    "createdAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "privacy": {
+                      "type": "string",
+                      "enum": [
+                        "public",
+                        "unlisted",
+                        "private"
+                      ],
+                      "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "interval",
+                        "http",
+                        "express",
+                        "email",
+                        "script",
+                        "rpc"
+                      ]
+                    },
+                    "author": {
+                      "anyOf": [
+                        {
+                          "description": "The user who created this val",
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "format": "uuid",
+                              "type": "string"
+                            },
+                            "username": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "username"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "likeCount": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "referenceCount": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "readme": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "id",
+                    "version",
+                    "code",
+                    "public",
+                    "createdAt",
+                    "privacy",
+                    "type",
+                    "author",
+                    "likeCount",
+                    "referenceCount",
+                    "readme"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/me": {
+      "get": {
+        "operationId": "meGet",
+        "tags": [
+          "me"
+        ],
+        "description": "Get profile information for the current user",
+        "responses": {
+          "200": {
+            "description": "User information, with tier included",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "User information, with tier included",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "bio": {
+                      "anyOf": [
+                        {
+                          "description": "The user’s biography, if they have provided one",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "username": {
+                      "anyOf": [
+                        {
+                          "description": "The user’s handle that they chose for themselves. Does not include the @ symbol",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "profileImageUrl": {
+                      "anyOf": [
+                        {
+                          "description": "URL that points to the user’s profile image, if one exists",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "tier": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "free",
+                            "pro"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "bio",
+                    "username",
+                    "profileImageUrl",
+                    "tier"
+                  ]
+                },
+                "example": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "bio": "Hello world",
+                  "username": "tmcw",
+                  "profileImageUrl": null,
+                  "tier": "pro"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/me/likes": {
+      "get": {
+        "operationId": "meLikes",
+        "tags": [
+          "me"
+        ],
+        "description": "Get vals liked by the current user",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BasicVal"
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/me/comments": {
+      "get": {
+        "operationId": "meComments",
+        "tags": [
+          "me"
+        ],
+        "description": "Get comments related to current user, either given or received",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "description": "Include items created after this date"
+          },
+          {
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "description": "Include items created before this date"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "any",
+                "received",
+                "given"
+              ],
+              "default": "any"
+            },
+            "in": "query",
+            "name": "relationship",
+            "required": true,
+            "description": "Whether to get comments you have received, given, or both"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "comment": {
+                            "description": "Text of the given comment, in Markdown",
+                            "type": "string"
+                          },
+                          "id": {
+                            "format": "uuid",
+                            "description": "The comment’s id",
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "author": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "username": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username"
+                            ]
+                          },
+                          "val": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the val that is being commented on",
+                                "type": "string"
+                              },
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "version": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "privacy": {
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "unlisted",
+                                  "private"
+                                ],
+                                "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+                              },
+                              "author": {
+                                "anyOf": [
+                                  {
+                                    "description": "The user who created this val",
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "format": "uuid",
+                                        "type": "string"
+                                      },
+                                      "username": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "username"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "id",
+                              "version",
+                              "privacy",
+                              "author"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "comment",
+                          "id",
+                          "createdAt",
+                          "author",
+                          "val"
+                        ]
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/me/references": {
+      "get": {
+        "operationId": "meReferences",
+        "tags": [
+          "me"
+        ],
+        "description": "Get vals that depend on any of the user's vals",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "description": "Include items created after this date"
+          },
+          {
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "description": "Include items created before this date"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "reference": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "username": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "author_id": {
+                                "anyOf": [
+                                  {
+                                    "format": "uuid",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "author_id",
+                              "name"
+                            ]
+                          },
+                          "dependsOn": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "username": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "author_id": {
+                                "anyOf": [
+                                  {
+                                    "format": "uuid",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "username",
+                              "author_id",
+                              "name"
+                            ]
+                          },
+                          "referencedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "reference",
+                          "dependsOn",
+                          "referencedAt"
+                        ]
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/blob": {
+      "get": {
+        "operationId": "blobsList",
+        "tags": [
+          "blobs"
+        ],
+        "description": "List blobs in your account",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "prefix",
+            "required": false,
+            "description": "If specified, only include blobs that start with this string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of blobs that you’ve stored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "List of blobs that you’ve stored",
+                  "type": "array",
+                  "items": {
+                    "title": "BlobListingItem",
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "size": {
+                        "description": "Size in bytes of the object",
+                        "type": "integer"
+                      },
+                      "lastModified": {
+                        "description": "Creation date of the object",
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ]
+                  }
+                },
+                "example": [
+                  {
+                    "key": "hello_world",
+                    "size": 20,
+                    "lastModified": "2024-06-24T20:00:59.702Z"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/blob/{key}": {
+      "get": {
+        "operationId": "blobsGet",
+        "tags": [
+          "blobs"
+        ],
+        "description": "Get a blob’s contents.",
+        "parameters": [
+          {
+            "schema": {
+              "minLength": 1,
+              "maxLength": 512,
+              "type": "string"
+            },
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "description": "Key that uniquely identifies this blob"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Binary contents of the returned file",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "blobsStore",
+        "tags": [
+          "blobs"
+        ],
+        "description": "Store data in blob storage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "format": "binary",
+                "description": "Binary input data",
+                "type": "string"
+              }
+            }
+          },
+          "description": "Binary input data"
+        },
+        "parameters": [
+          {
+            "schema": {
+              "minLength": 1,
+              "maxLength": 512,
+              "type": "string"
+            },
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "description": "Key that uniquely identifies this blob"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully stored as blob"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "blobsDelete",
+        "tags": [
+          "blobs"
+        ],
+        "description": "Delete a blob",
+        "parameters": [
+          {
+            "schema": {
+              "minLength": 1,
+              "maxLength": 512,
+              "type": "string"
+            },
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "description": "Key that uniquely identifies this blob"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Blob successfully deleted"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}": {
+      "get": {
+        "operationId": "usersGet",
+        "tags": [
+          "users"
+        ],
+        "description": "Get basic information about a user",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "description": "User Id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/vals": {
+      "get": {
+        "operationId": "usersVals",
+        "tags": [
+          "users"
+        ],
+        "description": "List a user's vals",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "description": "User Id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BasicVal"
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sqlite/execute": {
+      "post": {
+        "operationId": "sqliteExecute",
+        "tags": [
+          "sqlite"
+        ],
+        "description": "Execute a single SQLite statement and return results",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "A single statement to run",
+                "type": "object",
+                "properties": {
+                  "statement": {
+                    "anyOf": [
+                      {
+                        "description": "Simple SQL statement to run in SQLite",
+                        "type": "string"
+                      },
+                      {
+                        "title": "ParameterizedQuery",
+                        "description": "A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference",
+                        "type": "object",
+                        "properties": {
+                          "sql": {
+                            "description": "SQL statement, with ? placeholders for arguments",
+                            "type": "string"
+                          },
+                          "args": {
+                            "description": "List of arguments to be used in the given statement",
+                            "anyOf": [
+                              {
+                                "type": "array",
+                                "items": {
+                                  "description": "A value to be used as a parameter",
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "description": "A value to be used as a parameter",
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "sql",
+                          "args"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "statement"
+                ]
+              },
+              "examples": {
+                "example1": {
+                  "value": {
+                    "statement": "SELECT 1;"
+                  }
+                },
+                "example2": {
+                  "value": {
+                    "statement": {
+                      "sql": "SELECT * FROM table WHERE column = ?;",
+                      "args": [
+                        1
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true,
+          "description": "A single statement to run"
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultSet"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sqlite/batch": {
+      "post": {
+        "operationId": "sqliteBatch",
+        "tags": [
+          "sqlite"
+        ],
+        "description": "Execute a batch of SQLite statements and return results for all of them",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "A set of statements to be run in a single batch",
+                "type": "object",
+                "properties": {
+                  "statements": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "Simple SQL statement to run in SQLite",
+                          "type": "string"
+                        },
+                        {
+                          "title": "ParameterizedQuery",
+                          "description": "A parameterized SQL query. See https://docs.turso.tech/sdk/ts/reference#batch-transactions for reference",
+                          "type": "object",
+                          "properties": {
+                            "sql": {
+                              "description": "SQL statement, with ? placeholders for arguments",
+                              "type": "string"
+                            },
+                            "args": {
+                              "description": "List of arguments to be used in the given statement",
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "description": "A value to be used as a parameter",
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "description": "A value to be used as a parameter",
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "sql",
+                            "args"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "write",
+                      "read",
+                      "deferred"
+                    ]
+                  }
+                },
+                "required": [
+                  "statements"
+                ]
+              },
+              "example": {
+                "statements": [
+                  "SELECT 1;"
+                ],
+                "mode": "read"
+              }
+            }
+          },
+          "required": true,
+          "description": "A set of statements to be run in a single batch"
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of results from the statements executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Array of results from the statements executed",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResultSet"
+                  }
+                },
+                "example": [
+                  {
+                    "columns": [
+                      "id"
+                    ],
+                    "columnTypes": [
+                      "number"
+                    ],
+                    "rows": [
+                      [
+                        1
+                      ]
+                    ],
+                    "rowsAffected": 0,
+                    "lastInsertRowid": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/eval": {
+      "post": {
+        "operationId": "evalPost",
+        "tags": [
+          "vals"
+        ],
+        "description": "Run JavaScript or TypeScript without saving it permanently as a val",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "maxLength": 8192,
+                    "description": "TypeScript source code",
+                    "type": "string"
+                  },
+                  "args": {
+                    "description": "Array of arguments passed to the given function",
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              },
+              "example": {
+                "code": "console.log(1);"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/eval/{code}": {
+      "get": {
+        "operationId": "evalGet",
+        "tags": [
+          "vals"
+        ],
+        "description": "Run JavaScript or TypeScript without saving it permanently as a val",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "args",
+            "required": false
+          },
+          {
+            "schema": {
+              "maxLength": 8192,
+              "type": "string"
+            },
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "description": "TypeScript source code"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The function throw an error or had invalid syntax",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The function throw an error or had invalid syntax",
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/run/{valname}": {
+      "get": {
+        "operationId": "runGet",
+        "tags": [
+          "vals"
+        ],
+        "description": "Run a val, specify any parameters in a querystring",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "args",
+            "required": false,
+            "description": "An argument that will be passed to the function as a JavaScript value"
+          },
+          {
+            "schema": {
+              "pattern": "^[^.]+.[^.]+$",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "valname",
+            "required": true,
+            "description": "Name of the val, in concatenated style, like username.valname"
+          }
+        ],
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "post": {
+        "operationId": "runPost",
+        "tags": [
+          "vals"
+        ],
+        "description": "Run a val, with arguments in the request body",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Arguments to call the method with",
+                "type": "object",
+                "properties": {
+                  "args": {
+                    "type": "array",
+                    "items": {}
+                  }
+                }
+              },
+              "example": {
+                "args": [
+                  1
+                ]
+              }
+            }
+          },
+          "description": "Arguments to call the method with"
+        },
+        "parameters": [
+          {
+            "schema": {
+              "pattern": "^[^.]+.[^.]+$",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "valname",
+            "required": true,
+            "description": "Name of the val, in concatenated style, like username.valname"
+          }
+        ],
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v1/email": {
+      "post": {
+        "operationId": "emailsSend",
+        "tags": [
+          "emails"
+        ],
+        "description": "Send emails",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Fields for an email to be sent",
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "description": "The subject line of the email",
+                    "type": "string"
+                  },
+                  "from": {
+                    "title": "EmailData",
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "title": "EmailNameAndAddress",
+                        "description": "An email address and name",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "email"
+                        ]
+                      }
+                    ]
+                  },
+                  "to": {
+                    "description": "A single email or list of emails for one of the address fields",
+                    "anyOf": [
+                      {
+                        "title": "EmailData",
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "title": "EmailNameAndAddress",
+                            "description": "An email address and name",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "email": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "email"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "EmailDataList",
+                        "type": "array",
+                        "items": {
+                          "title": "EmailData",
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "title": "EmailNameAndAddress",
+                              "description": "An email address and name",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "email": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "email"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "cc": {
+                    "description": "A single email or list of emails for one of the address fields",
+                    "anyOf": [
+                      {
+                        "title": "EmailData",
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "title": "EmailNameAndAddress",
+                            "description": "An email address and name",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "email": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "email"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "EmailDataList",
+                        "type": "array",
+                        "items": {
+                          "title": "EmailData",
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "title": "EmailNameAndAddress",
+                              "description": "An email address and name",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "email": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "email"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "bcc": {
+                    "description": "A single email or list of emails for one of the address fields",
+                    "anyOf": [
+                      {
+                        "title": "EmailData",
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "title": "EmailNameAndAddress",
+                            "description": "An email address and name",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "email": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "email"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "EmailDataList",
+                        "type": "array",
+                        "items": {
+                          "title": "EmailData",
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "title": "EmailNameAndAddress",
+                              "description": "An email address and name",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "email": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "email"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "text": {
+                    "description": "Text content of the email, for email clients that may not support HTML",
+                    "type": "string"
+                  },
+                  "html": {
+                    "description": "HTML content of the email. Can be specified alongside text",
+                    "type": "string"
+                  },
+                  "attachments": {
+                    "description": "A list of attachments to add to the email",
+                    "type": "array",
+                    "items": {
+                      "title": "AttachmentObject",
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "disposition": {
+                          "type": "string"
+                        },
+                        "contentId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "filename"
+                      ]
+                    }
+                  },
+                  "replyToList": {
+                    "title": "ReplyToList",
+                    "description": "A reply-to list of email addresses",
+                    "anyOf": [
+                      {
+                        "title": "EmailNameAndAddress",
+                        "description": "An email address and name",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "email"
+                        ]
+                      },
+                      {
+                        "title": "EmailList",
+                        "type": "array",
+                        "items": {
+                          "title": "EmailNameAndAddress",
+                          "description": "An email address and name",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "email"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "example": {
+                "subject": "An important message",
+                "text": "Hello world",
+                "html": "Hello <strong>world</strong>"
+              }
+            }
+          },
+          "description": "Fields for an email to be sent"
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully sent email",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Successfully sent email",
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/vals": {
+      "post": {
+        "operationId": "valsCreate",
+        "tags": [
+          "vals"
+        ],
+        "description": "Create a new val",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Val information provided to create a new val",
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "minLength": 1,
+                    "maxLength": 256000,
+                    "description": "Val source code as TypeScript",
+                    "type": "string"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "maxLength": 48,
+                    "description": "This val’s name",
+                    "type": "string"
+                  },
+                  "readme": {
+                    "maxLength": 8192,
+                    "description": "Readme contents, as Markdown",
+                    "type": "string"
+                  },
+                  "privacy": {
+                    "type": "string",
+                    "enum": [
+                      "public",
+                      "unlisted",
+                      "private"
+                    ],
+                    "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "http",
+                      "script",
+                      "email"
+                    ],
+                    "default": "script"
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              },
+              "example": {
+                "code": "console.log(1);",
+                "name": "myVal",
+                "readme": "# My Val",
+                "privacy": "public",
+                "type": "script"
+              }
+            }
+          },
+          "required": true,
+          "description": "Val information provided to create a new val"
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedVal"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "valsPut",
+        "tags": [
+          "vals"
+        ],
+        "description": "Run an existing val or create a new one",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Create a new val, or version of a val, with new code",
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "minLength": 1,
+                    "maxLength": 256000,
+                    "description": "Val source code as TypeScript",
+                    "type": "string"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "maxLength": 48,
+                    "description": "This val’s name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "name"
+                ]
+              },
+              "example": {
+                "code": "console.log(1);",
+                "name": "myVal"
+              }
+            }
+          },
+          "required": true,
+          "description": "Create a new val, or version of a val, with new code"
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v1/vals/{val_id}": {
+      "get": {
+        "operationId": "valsGet",
+        "tags": [
+          "vals"
+        ],
+        "description": "Get a val by id",
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedVal"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "valsUpdate",
+        "tags": [
+          "vals"
+        ],
+        "description": "Update an existing val",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Note: you must supply at least one of the keys in this object in order to update a val",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "maxLength": 48,
+                    "description": "This val’s name",
+                    "type": "string"
+                  },
+                  "readme": {
+                    "maxLength": 8192,
+                    "description": "Readme contents, as Markdown",
+                    "type": "string"
+                  },
+                  "privacy": {
+                    "type": "string",
+                    "enum": [
+                      "public",
+                      "unlisted",
+                      "private"
+                    ],
+                    "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+                  }
+                }
+              },
+              "example": {
+                "readm": "# Updated readme",
+                "name": "myVal"
+              }
+            }
+          },
+          "description": "Note: you must supply at least one of the keys in this object in order to update a val"
+        },
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Val successfully updated"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "valsDelete",
+        "tags": [
+          "vals"
+        ],
+        "description": "Delete a val",
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Val successfully deleted"
+          },
+          "404": {
+            "description": "The val was not found"
+          }
+        }
+      }
+    },
+    "/v1/vals/{val_id}/versions": {
+      "get": {
+        "operationId": "valsList",
+        "tags": [
+          "vals"
+        ],
+        "description": "List versions of a val",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A paginated result set",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "val_id": {
+                            "format": "uuid",
+                            "description": "Id of a val",
+                            "type": "string"
+                          },
+                          "version": {
+                            "minimum": 0,
+                            "description": "Version of the val",
+                            "type": "integer"
+                          },
+                          "createdAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "val_id",
+                          "version",
+                          "createdAt"
+                        ]
+                      }
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/PaginationLinks"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "links"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "valsCreateVersion",
+        "tags": [
+          "vals"
+        ],
+        "description": "Create a new version of a val",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Val information provided to create a new val",
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "minLength": 1,
+                    "maxLength": 256000,
+                    "description": "Val source code as TypeScript",
+                    "type": "string"
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "maxLength": 48,
+                    "description": "This val’s name",
+                    "type": "string"
+                  },
+                  "readme": {
+                    "maxLength": 8192,
+                    "description": "Readme contents, as Markdown",
+                    "type": "string"
+                  },
+                  "privacy": {
+                    "type": "string",
+                    "enum": [
+                      "public",
+                      "unlisted",
+                      "private"
+                    ],
+                    "description": "This val’s privacy setting. Unlisted vals do not appear on profile pages or elsewhere, but you can link to them."
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "http",
+                      "script",
+                      "email"
+                    ],
+                    "default": "script"
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              },
+              "example": {
+                "code": "console.log(1);",
+                "name": "myVal",
+                "readme": "# My Val",
+                "privacy": "public",
+                "type": "script"
+              }
+            }
+          },
+          "required": true,
+          "description": "Val information provided to create a new val"
+        },
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedVal"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/vals/{val_id}/versions/{version}": {
+      "get": {
+        "operationId": "valsGetVersion",
+        "tags": [
+          "vals"
+        ],
+        "description": "Get a specific version of a val",
+        "parameters": [
+          {
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "description": "Number of items to skip in order to deliver paginated results"
+          },
+          {
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "description": "Maximum items to return in each paginated response"
+          },
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          },
+          {
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "description": "The val version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedVal"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "valsDeleteVersion",
+        "tags": [
+          "vals"
+        ],
+        "description": "Delete a specific version of a val",
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "val_id",
+            "required": true,
+            "description": "Id of a val"
+          },
+          {
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "description": "The val version"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Version successfully deleted"
+          },
+          "404": {
+            "description": "The val was not found"
+          }
+        }
+      }
+    },
+    "/v1/vals/{evaluation_id}/cancel": {
+      "post": {
+        "operationId": "valsCancel",
+        "tags": [
+          "vals"
+        ],
+        "description": "Cancel a running val",
+        "parameters": [
+          {
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "in": "path",
+            "name": "evaluation_id",
+            "required": true,
+            "description": "The ID of the evaluation - the specific time that a val was run - that you want to cancel"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The evaluation_id was successfully searched for and the evaluation was either already done or now has been cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The evaluation_id was successfully searched for and the evaluation was either already done or now has been cancelled",
+                  "type": "object",
+                  "properties": {
+                    "found": {
+                      "description": "True if the evaluation was found and cancelled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "found"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3001",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "vals",
+      "description": "These endpoints\nlet you get, create, and run vals."
+    },
+    {
+      "name": "alias",
+      "description": "Many API endpoints\naccept IDs instead of user-facing names. The alias\nendpoints let you convert between the user-facing name of a\nval or another object into an ID that can be used with other\nAPI endpoints"
+    },
+    {
+      "name": "me",
+      "description": "These endpoints\ngive access to details and data from the requesting user."
+    },
+    {
+      "name": "users",
+      "description": "Users"
+    },
+    {
+      "name": "sqlite",
+      "description": "SQLite"
+    },
+    {
+      "name": "blobs",
+      "description": "Blobs"
+    },
+    {
+      "name": "search",
+      "description": "Search"
+    },
+    {
+      "name": "emails",
+      "description": "Emails"
+    }
+  ],
+  "externalDocs": {
+    "url": "http://localhost:3001/documentation",
+    "description": "Find more info here"
+  }
+}


### PR DESCRIPTION
Adds an OpenAPI docs page at `/openapi`. This will theoretically replace https://api.val.town/documentation - and come with the benefit of integrated code examples.