### PR TITLE
add region to s3 endpoint

### DIFF
--- a/src/content/docs/integrations/s3.mdx
+++ b/src/content/docs/integrations/s3.mdx
@@ -91,7 +91,7 @@ Copy and run the following val in your workspace.
 import { S3Client } from "https://deno.land/x/s3_lite_client@0.6.1/mod.ts";
 
 const s3client = new S3Client({
-  endPoint: "s3.amazonaws.com",
+  endPoint: `s3.${Deno.env.get("awsS3Region")}.amazonaws.com`,
   region: Deno.env.get("awsS3Region"),
   bucket: Deno.env.get("awsS3Bucket"),
   accessKey: Deno.env.get("awsS3Key"),

--- a/src/content/docs/integrations/s3.mdx
+++ b/src/content/docs/integrations/s3.mdx
@@ -111,7 +111,7 @@ Copy and run the following val in your workspace.
 import { S3Client } from "https://deno.land/x/s3_lite_client@0.6.1/mod.ts";
 
 const s3client = new S3Client({
-  endPoint: "s3.amazonaws.com",
+  endPoint: `s3.${Deno.env.get("awsS3Region")}.amazonaws.com`,
   region: Deno.env.get("awsS3Region"),
   bucket: Deno.env.get("awsS3Bucket"),
   accessKey: Deno.env.get("awsS3Key"),


### PR DESCRIPTION
Existing endpoint triggers a

``The server unexpectedly returned a redirect response. With AWS S3, this usually means you need to use a ` +
            `region-specific endpoint like "s3.us-west-2.amazonaws.com" instead of "s3.amazonaws.com"``