### PR TITLE
Add bot limits

### DIFF
--- a/src/content/docs/reference/bot-rate-limiting.mdx
+++ b/src/content/docs/reference/bot-rate-limiting.mdx
@@ -1,0 +1,22 @@
+---
+title: Bot rate limiting
+description: Some bots are rate limited across all Vals
+lastUpdated: 2025-01-07
+sidebar:
+  order: 1
+---
+
+We rate limit a small number of crawlers/bots that we identify by their
+`User-Agent` Header. These bots generated an inordinate amount of traffic
+(they are particularly fond of [playing chess](https://maxm-staticchess.web.val.run/)).
+We've placed a global rate limit on their request volume. They are collectively
+allowed 1000 reqests every 5 minutes.
+
+This list may change at any time, we'll do our best to keep it up to date.
+
+| User-Agent |
+|------------|
+| `meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)` |
+| `Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)` |
+| `Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)` |
+| `Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)` |

--- a/src/content/docs/reference/bot-rate-limiting.mdx
+++ b/src/content/docs/reference/bot-rate-limiting.mdx
@@ -10,7 +10,7 @@ We rate limit a small number of crawlers/bots that we identify by their
 `User-Agent` Header. These bots generated an inordinate amount of traffic
 (they are particularly fond of [playing chess](https://maxm-staticchess.web.val.run/)).
 We've placed a global rate limit on their request volume. They are collectively
-allowed 1000 reqests every 5 minutes.
+allowed 500 reqests every 5 minutes.
 
 This list may change at any time, we'll do our best to keep it up to date.
 


### PR DESCRIPTION
The new page: https://bot-limits.val-town-docs.pages.dev/reference/bot-rate-limiting/