### PR TITLE
Deprecate SQLite wasm in favor of new `std/sqlite`

### DIFF
--- a/src/content/docs/integrations/sqlite-wasm.mdx
+++ b/src/content/docs/integrations/sqlite-wasm.mdx
@@ -9,6 +9,12 @@ lastUpdated: 2023-12-04
 # cspell:ignore pagefind
 ---
 
+:::caution[Deprecated]
+
+New vals [should use `std/sqlite` instead](/std/SQLite), which is a private SQLite database that comes with every Val Town account.
+
+:::
+
 import Val from "@components/Val.astro";
 
 You can create, insert, query, and persist a whole SQLite database in Val Town via wasm!


### PR DESCRIPTION
The docs show two ways to do SQLite-in-val: [SQLite wasm](https://docs.val.town/integrations/sqlite-wasm/), and [`std/sqlite`](https://docs.val.town/std/sqlite/), which is much more performant.

I'd propose deprecating the older solution.