### PR TITLE
Fix SQLite WASM deprecation URL

### DIFF
--- a/src/content/docs/integrations/sqlite-wasm.mdx
+++ b/src/content/docs/integrations/sqlite-wasm.mdx
@@ -11,7 +11,7 @@ lastUpdated: 2023-12-04
 
 :::caution[Deprecated]
 
-New vals [should use `std/sqlite` instead](/std/SQLite), which is a private SQLite database that comes with every Val Town account.
+New vals [should use `std/sqlite` instead](/std/sqlite), which is a private SQLite database that comes with every Val Town account.
 
 :::
 


### PR DESCRIPTION
Oops! I had the wrong casing for the SQLite WASM deprecation link in #248.