### PR TITLE
Added Projects to Environment Variables docs

### DIFF
--- a/src/content/docs/reference/environment-variables.mdx
+++ b/src/content/docs/reference/environment-variables.mdx
@@ -8,8 +8,9 @@ sidebar:
 
 import Val from "@components/Val.astro";
 
-The proper place to store secrets, keys, and API tokens is in
-[Environment Variables](https://val.town/settings/environment-variables).
+You can store secrets, keys, and API token in two places:
+- [Global Environment Variables](https://val.town/settings/environment-variables): For single Vals, but **not accessible in Projects**.
+- Project Environment Variables: Added through the Project's left side bar.
 
 Environment variables can be accessed via `Deno.env` or `process.env`.
 


### PR DESCRIPTION
This page is linked in the global environment variables page. 
<img width="857" alt="Screenshot 2025-01-30 at 10 39 17 AM" src="https://github.com/user-attachments/assets/dfe02b67-ba67-4d94-b4c9-8645fd109c1c" />

Adding a line about Project environment variables for clarity.