### PR TITLE
Add a projects page that mentions local development

### DIFF
--- a/src/content/docs/projects/localdev.mdx
+++ b/src/content/docs/projects/localdev.mdx
@@ -1,0 +1,12 @@
+---
+title: Local Development
+description: Edit your projects locally
+sidebar:
+  order: 4
+---
+
+Val Town has an official command line tool for editing your val town projects locally, `vt`.
+
+`vt` is much like git. With `vt`, you can clone a Val Town project, edit the project locally, and then push to Val Town. `vt` also has a watch command, which lets you sync a folder on your computer live with Val Town, so you can use your favorite local tools to edit the project, and automatically have changes propogate to the website.
+
+For more information on `vt`, check out the [`vt` JSR page](https://jsr.io/@valtown/vt).

--- a/src/content/docs/quickstarts/prompting.mdx
+++ b/src/content/docs/quickstarts/prompting.mdx
@@ -26,20 +26,11 @@ You can also access Townie by clicking `Edit in Townie` in any val.
 
 ### Edit Projects with your Favorite IDE
 
-#### Step 1: Setup 
-Use Val Town with your preferred IDE by first cloning your project locally with our [Val Town CLI](https://github.com/val-town/vt):
+Use Val Town with your preferred IDE you can use [`vt`, the Val Town CLI](https://jsr.io/@valtown/vt).
 
-``` bash
-# Install CLI
-deno install -gAfr jsr:@valtown/vt
+To get started, install `vt` with `deno install -grAf jsr:@valtown/vt`, and then clone the project with `vt clone my-project`.
 
-# Set API token
-export VAL_TOWN_API_KEY=vtwn_replaceThis
-
-# Clone project locally
-vt clone my-project
-
-```
+Then, you can `cd my-project` to enter into the folder, and use `vt watch` to keep the folder synced with Val Town when changes are made locally.
 
 #### Step 2: Add Val Town System Prompt
 For each IDE, add our [system prompt](https://www.val.town/x/stevekrouse/OpenTownie/code/prompts/system_prompt.txt) as follows:


### PR DESCRIPTION
Add a page that talks about VT and references documentation on jsr. Update the previous `vt` mention to disclude the auth process, since that's now automatic-ish.