### PR TITLE
Updated SDK starter and default API token injection

### DIFF
--- a/src/content/docs/api/authentication.mdx
+++ b/src/content/docs/api/authentication.mdx
@@ -9,6 +9,8 @@ You can create and manage your API tokens on the [API Tokens page](https://www.v
 
 If you're using the Val Town API from within Val Town, a short-lived API token is automatically injected into your environment variables. These injected tokens are what provide authenticated access to Val Town Standard Library services.
 
+You can access your API token in your vals: `Deno.env.get('valtown')`
+
 All tokens are scoped to the permissions you've granted them.
 
 ## Scopes

--- a/src/content/docs/api/sdk.mdx
+++ b/src/content/docs/api/sdk.mdx
@@ -41,7 +41,7 @@ import ValTown from "npm:@valtown/sdk";
 
 const vt = new ValTown();
 
-// print your username
+// print your email
 const me = await vt.me.profile.retrieve();
 console.log(me.email);
 

--- a/src/content/docs/api/sdk.mdx
+++ b/src/content/docs/api/sdk.mdx
@@ -46,12 +46,8 @@ const me = await vt.me.profile.retrieve();
 console.log(me.email);
 
 // list some of your vals
-const { data: vals } = await vt.users.vals.list(me.id, {});
+const vals = await vt.me.vals.list({});
 console.log(vals);
-
-// list vals you've liked
-const { data: likes } = await vt.me.likes.list({});
-console.log(likes);
 ```
 
 Authentication is set by the `VAL_TOWN_API_KEY` environment


### PR DESCRIPTION
- Updated SDK starter, it's currently broken after recent SDK changes.
![CleanShot 2025-07-09 at 18 31 00@2x](https://github.com/user-attachments/assets/feda5d91-8956-4ba0-a259-f8cee4f530c7)
- Added clarity around how to access your default injected Val Town API token
![CleanShot 2025-07-09 at 18 28 11@2x](https://github.com/user-attachments/assets/c34ec9f8-b6c8-4789-8cc8-abf74473fde6)

(Thanks to @dcm31 for flagging that these are out of date) :) 