### PR TITLE
docs: branch feature updates

### DIFF
--- a/src/content/docs/vals/branches.mdx
+++ b/src/content/docs/vals/branches.mdx
@@ -7,11 +7,13 @@ sidebar:
 
 Every val has a `main` branch, which is the default branch. You can create branches off the `main` branch for feature development, testing, and sharing.
 
-## Creating a branch
+## Managing branches
 
 You need to be the owner of a val to create a branch. If you are not the owner, you can [remix the val](../remixes) and send a pull request.
 
-You can branch off `main` or any other branch.
+You can branch off `main` or any other branch from the default val page.
+
+You can create, delete or rename any branch from the val's navigation sidebar.
 
 ## Merging
 
@@ -46,7 +48,6 @@ This is the branch
 
 ### Limitations
 
-- Parent-child relationships are fixed. You can't change the base branch or re-parent a branch.
+- Parent-child relationships are fixed. You can't change the base branch or re-parent a branch. You can only merge a branch into what it was originally forked from.⁠
 - There is no support for squashing or rebasing changes.
-- You cannot delete a branch currently, but we will add that soon.
 - You cannot change the name of the `main` branch.


### PR DESCRIPTION
Improving some documentation around managing branches. I couldn't find universal naming for language around the val interfaces such as `val's sidebar` or `val view page` or `val edit page`. So hopefully this is clear enough but happy to make changes.