### PR TITLE
Fix Pushover example

### DIFF
--- a/src/content/docs/guides/push-notifications.mdx
+++ b/src/content/docs/guides/push-notifications.mdx
@@ -2,7 +2,7 @@
 title: Push notifications
 generated: 1701279907821
 description: Using the third-party service ntfy.sh, you can send push notifications to phones and computer with Val Town.
-lastUpdated: 2023-12-08
+lastUpdated: 2025-09-08
 # cspell:ignore ntfy axelav
 ---
 
@@ -29,4 +29,4 @@ yourself push notifications to your phone.
 For iOS, [Pushover](https://pushover.net/) is another great way to get push
 notifications.
 
-<Val url="https://www.val.town/embed/meatcar/pushover" />
+<Val url="https://www.val.town/embed/jacobbudin/pushover" />


### PR DESCRIPTION
The current Pushover example ([meatcar/pushover](https://www.val.town/x/meatcar/pushover)) does not work. The function will always return a 400 HTTP response:
```
{
  "token": "invalid",
  "errors": [
    "application token must be supplied, see https://pushover.net/api"
  ],
  "status": 0,
  "request": "..."
}
```

According to [their API documentation](https://pushover.net/api#messages):
> We do not support receiving XML-encoded parameters, only the standard [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) that most HTTP libraries default to, and JSON with a `Content-Type` of `application/json`.

Setting the Content-Type header to `application/json` makes the function work.