### PR TITLE
MCP server docs - update the Claude Code example

### DIFF
--- a/src/content/docs/guides/Prompting/mcp.mdx
+++ b/src/content/docs/guides/Prompting/mcp.mdx
@@ -19,11 +19,13 @@ Use the Val Town MCP server to work with Val Town in your preferred AI tool, e.g
 
 </Steps>
 
+E.g. for Claude Code:
+
 ```
-# E.g. for Claude Code
-> claude mcp add --transport http val-town https://api.val.town/v3/mcp
-> /mcp
+claude mcp add --transport http val-town https://api.val.town/v3/mcp
 ```
+
+In Claude, type `/mcp` to confirm that it's connected, and authenticate if necessary.
 
 ## Popular tools
 


### PR DESCRIPTION
The existing example doesn't copy-paste directly (into the Terminal), and needs to be edited first. This change moves the explanatory text outside the copy-paste example.