### PR TITLE
Update SQLite Admin Panels list

### DIFF
--- a/src/content/docs/reference/std/SQLite/index.mdx
+++ b/src/content/docs/reference/std/SQLite/index.mdx
@@ -37,8 +37,7 @@ Val Town SQLite is powered by [Turso](https://turso.tech/).
 We recommend these admin data viewers for managing your database – viewing or editing data or your database table schema:
 
 - [Outerbase Studio](https://libsqlstudio.com/) **(recommended)** - formerly LibSQL Studio – see [instructions](https://libsqlstudio.com/docs/connect-valtown)
-- [SQLite Explorer React](https://www.val.town/x/nbbaier/sqliteExplorerReact) - built in a val - access your database with Val Town oauth.
-- [SQLite Explorer](https://www.val.town/v/nbbaier/sqliteExplorerApp) (deprecated) – built in easy – easy to customize in Val Town!
+- [SQLite Explorer React](https://www.val.town/x/nbbaier/sqliteExplorerReact) - built in a val - access your database with Val Town oauth
 
 ### Limits
 


### PR DESCRIPTION
I've edited the list of Val Town sqlite admin panels so that the sqlite explorer link points to my new [React version](https://www.val.town/x/nbbaier/sqliteExplorerReact) of SQLite Explorer.