### PR TITLE
Add tip about version pinning

### DIFF
--- a/src/content/docs/reference/version-control.mdx
+++ b/src/content/docs/reference/version-control.mdx
@@ -5,7 +5,7 @@ description: Every time you save a val it creates a new immutable version in the
 lastUpdated: 2025-01-30
 ---
 
-Vals are immutable, but you can publish new versions of vals. Versions start at `0` and go up from there, auto-incrementing when you save files, add/remove files and folders, and take other actions. You can browse, revert, and diff versions in a val's `History` (navigate there via the val sidebar).
+Vals are versioned, starting at `0`. A val's version auto-increments when you save files, add/remove files and folders, and take other actions. You can browse, revert, and diff versions in a val's `History` (navigate there via the val sidebar).
 
 ## Imports & pinning
 


### PR DESCRIPTION
- Fixes instructions on how to switch versions
- Adds a tip that pinning is often safest
- Adds option to force-regenerate lockfile

Thanks to Edward for the [nudge](https://valtown.slack.com/archives/C0A45MJBUVB/p1769131936587069)