### PR TITLE
Update basic usage example in the SQlite documentation

### DIFF
--- a/src/content/docs/reference/std/SQLite/usage.mdx
+++ b/src/content/docs/reference/std/SQLite/usage.mdx
@@ -3,7 +3,7 @@ title: Usage
 description: How to use Val Town SQLite, with examples.
 sidebar:
   order: 1
-lastUpdated: 2023-12-27
+lastUpdated: 2026-02-06
 # cspell:ignore specialkey specialvalue
 ---
 
@@ -49,14 +49,12 @@ console.log(result);
 // {
 //   columns: [ "key", "value" ],
 //   columnTypes: [ "TEXT", "TEXT" ],
-//   rows: [ [ "d65991f8-6f03-4275-bcf1-1fdb1164e153", "value1" ] ],
+//   rows: [ { key: "d65991f8-6f03-4275-bcf1-1fdb1164e153", value: "value1" } ],
 //   rowsAffected: 0,
 //   lastInsertRowid: null
 // }
 
-const rows: { key: string; value: string }[] = result.rows.map(row =>
-  Object.fromEntries(row.map((value, index) => [result.columns[index], value])) as any
-);
+const rows: { key: string; value: string }[] = result.rows as any;
 
 console.log(rows); // [ { key: "d65991f8-6f03-4275-bcf1-1fdb1164e153", value: "value1" } ]
 ```


### PR DESCRIPTION
I've made changes in the code example because in the new val-scoped database (imported from `sqlite/main.ts` instead of `sqlite/global.ts`), given that `result` is the result of `sqlite.execute`, the `result.rows` is not an array of array anymore but an array of object like standard SQL. Therefore we don't need the extra function to convert it into an array of object. It will cause a type error instead. I've made a demo here to remix to see the returned result: https://www.val.town/x/foliage/valScopedDatabaseDemo