### PR TITLE
Use max_completion_tokens instead of max_tokens for gpt-5-nano

### DIFF
--- a/src/content/docs/reference/std/openai.mdx
+++ b/src/content/docs/reference/std/openai.mdx
@@ -26,7 +26,7 @@ const completion = await openai.chat.completions.create({
     { role: "user", content: "Say hello in a creative way" },
   ],
   model: "gpt-5-nano",
-  max_tokens: 100,
+  max_completion_tokens: 16000,
 });
 
 console.log(completion.choices[0].message.content);


### PR DESCRIPTION
max_tokens doesn't appear to be forward compatible from gpt-4 to gpt-5 models and was throwing a 400 error in this example.