### PR TITLE
docs: update starter template links to new templates/* URLs

### DIFF
--- a/src/content/docs/guides/stripe.mdx
+++ b/src/content/docs/guides/stripe.mdx
@@ -64,7 +64,7 @@ Stripe Checkout is a more customizable way to link to Stripe. You first create a
   Docs: Stripe Checkout
 </LinkButton>
 
-We ported [Stripe Checkout Quickstart](https://docs.stripe.com/checkout/quickstart) to Val Town: https://val.town/v/std/stripeCheckoutQuickstart
+We ported [Stripe Checkout Quickstart](https://docs.stripe.com/checkout/quickstart) to Val Town: https://val.town/x/templates/stripe-checkout-quickstart
 
 ```ts
 // @ts-ignore

--- a/src/content/docs/guides/telegram.mdx
+++ b/src/content/docs/guides/telegram.mdx
@@ -35,7 +35,7 @@ Be sure to note down the `token` that @BotFather gives you. You will need it in 
 
 ### 2. Create a webhook handler to receive messages
 
-Remix this val to set up your webhook handler: [@std/telegramBotStarter](https://www.val.town/x/std/telegramBotStarter)
+Remix this val to set up your webhook handler: [@templates/telegram-bot-starter](https://www.val.town/x/templates/telegram-bot-starter)
 
 Go to your val's environment variables. Add the token from the previous step as `TELEGRAM_TOKEN`.
 


### PR DESCRIPTION
## Summary

Updates references to old `std/` starter vals to point at the new canonical `templates/` URLs.

## Mappings applied

- `std/reactHonoStarter` -> `templates/react-hono-starter`
- `std/basic-html-starter` -> `templates/basic-html-starter`
- `std/telegramBotStarter` -> `templates/telegram-bot-starter`
- `std/stripePaymentLinkStarter` -> `templates/stripe-payment-link-starter`
- `std/stripeCheckoutQuickstart` -> `templates/stripe-checkout-quickstart`

## Files changed

- `src/content/docs/guides/stripe.mdx` — link to `https://val.town/v/std/stripeCheckoutQuickstart` -> `https://val.town/x/templates/stripe-checkout-quickstart`
- `src/content/docs/guides/telegram.mdx` — `[@std/telegramBotStarter](https://www.val.town/x/std/telegramBotStarter)` -> `[@templates/telegram-bot-starter](https://www.val.town/x/templates/telegram-bot-starter)`

Grepped `src/` for all four URL patterns (`val.town/x/std/<name>`, `esm.town/v/std/<name>`, `@std/<name>`, `std/<name>` in prose) across each of the five starter identifiers — only the two files above matched. `guides/first-website.mdx` no longer references any `std/` starter.

## Test plan

- [ ] Render the docs site and confirm both links resolve to the new templates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->