### PR TITLE
Fix broken View-and-run links from #486

### DIFF
--- a/src/lib/val-source.ts
+++ b/src/lib/val-source.ts
@@ -91,7 +91,7 @@ function parseEmbedUrl(embedUrl: string): ParsedEmbed | null {
       valName,
       filePath,
       version: null,
-      valPageUrl: `https://www.val.town/x/${handle}/${valName}/${filePath}`,
+      valPageUrl: `https://www.val.town/x/${handle}/${valName}${filePath ? `/code/${filePath}` : ""}`,
     };
   }
 


### PR DESCRIPTION
#486's generated links to new-style val files omitted the /code/ path segment, so all 28 of them 404'd (e.g. val.town/x/templates/duck/events.ts instead of val.town/x/templates/duck/code/events.ts). One-line fix in the URL builder. Verified by building and curling all 53 generated links: 28x 200, 25x 302 (legacy /v/ aliases), zero 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->