### PR TITLE
Make llms-full.txt and sitemap discoverable

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://docs.val.town/sitemap-index.xml

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -33,6 +33,8 @@ export const GET: APIRoute = async () => {
   });
 
   let content = "# Val Town Documentation\n\n";
+  content +=
+    "- [Full documentation in one file](https://docs.val.town/llms-full.txt)\n\n";
 
   for (const section of sections) {
     const sectionDocs = docsBySection[section];


### PR DESCRIPTION
An agent fetching https://docs.val.town/llms.txt currently has no way to discover that llms-full.txt exists, so this adds one line at the top of the index linking the full corpus. It also adds a `Sitemap: https://docs.val.town/sitemap-index.xml` directive to robots.txt (the sitemap lives at sitemap-index.xml, not sitemap.xml, so crawlers can't guess it). Verified both outputs in dist/ after a local build; lint and cspell pass.

Companion PR adds /llms.txt on www.val.town pointing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->