### PR TITLE
Add six template guides

### DIFF
--- a/src/content/docs/guides/cache-rate-limited-api.mdx
+++ b/src/content/docs/guides/cache-rate-limited-api.mdx
@@ -1,0 +1,75 @@
+---
+title: Cache a rate-limited API behind your own endpoint
+description: Remix a two-file val where a cron caches an upstream API into
+  blob storage and an HTTP endpoint serves the cache instantly
+# cspell:ignore openweathermap Meteo
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+If an upstream API is rate-limited, the fix is to stop hitting it per
+request: a [cron val](/vals/cron/) fetches the upstream every 15 minutes and
+writes the result to [blob storage](/reference/std/blob/), and an
+[HTTP val](/vals/http/) serves that cached blob instantly. Your endpoint
+never talks to the upstream on request, so it's fast and your traffic never
+counts against the upstream's rate limit.
+
+## Why a keyed upstream matters
+
+On Val Town — or any serverless platform — outbound requests leave from
+shared egress IPs. Keyless APIs that rate-limit by IP (Open-Meteo, for
+example) count every other user's requests on that IP against "your" limit,
+so even one polite cron call can come back 429. An earlier version of this
+template used Open-Meteo and hit exactly that failure: the refresh cron
+itself got rate-limited by other users' traffic.
+
+The fix is an upstream with a per-key quota. This template uses
+OpenWeatherMap: the quota belongs to your API key, so nobody else on the
+shared IP can drain it. The cron-to-blob cache then keeps your own usage to
+one upstream call per interval, no matter how much traffic your endpoint
+gets.
+
+## The two files
+
+The cron half fetches the upstream and writes `{ fetchedAt, data }` to a
+blob:
+
+<Val url="https://www.val.town/embed/x/templates/cached-api-proxy/refresh.ts" />
+
+The HTTP half serves the cache with an `X-Cache-Age` header (and a 503 if
+the cache is empty):
+
+<Val url="https://www.val.town/embed/x/templates/cached-api-proxy/main.ts" />
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/cached-api-proxy)
+   — click the **Remix** button in the top right corner.
+2. Get a free API key at [openweathermap.org/api](https://openweathermap.org/api).
+3. Add it to your val's
+   [environment variables](/reference/environment-variables/) as
+   `OPENWEATHER_API_KEY`.
+4. Click **Run** on `refresh.ts` once to populate the cache, or wait for the
+   first cron run.
+5. Hit the `main.ts` endpoint URL and check the `X-Cache-Age` response
+   header to see how fresh the data is.
+
+To adapt it to your own API, change the URL in `refresh.ts` and adjust the
+cron schedule to taste. Keep reading the key with `Deno.env.get()` — it
+stays server-side and is never exposed to your endpoint's callers.
+
+## Notes
+
+- The 15-minute schedule (`*/15 * * * *`) is the fastest a cron can run on
+  the free plan; [Pro](https://www.val.town/pricing) allows up to once a
+  minute.
+- Cached data survives between runs in blob storage, so a failed refresh
+  just means slightly staler data, not an outage.
+
+## Next steps
+
+- [Blob storage reference](/reference/std/blob/) — what the cache is built on
+- [Cron reference](/vals/cron/) — schedule types and limits
+- [Environment variables](/reference/environment-variables/) — how secrets
+  stay private

--- a/src/content/docs/guides/github-star-notifications.mdx
+++ b/src/content/docs/guides/github-star-notifications.mdx
@@ -1,0 +1,50 @@
+---
+title: Get notified when someone stars your GitHub repo
+description: Remix a cron val that polls your repo's stargazers hourly and
+  emails you about every new star — no GitHub token required
+# cspell:ignore stargazers yourname yourrepo
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+GitHub doesn't email you when someone stars your repo, and the marketplace
+apps that do want an OAuth grant. This template is one
+[cron-triggered val](/vals/cron/) that polls the GitHub API for your repo's
+stargazers every hour, remembers who it has already seen in
+[blob storage](/reference/std/blob/), and emails you whenever someone new
+shows up. It uses GitHub's public keyless API, so there is nothing to sign
+up for — no tokens, no env vars.
+
+## The notifier
+
+<Val url="https://www.val.town/embed/x/templates/github-star-notifier/main.ts" />
+
+Stargazers come back from the API oldest-first, so the val checks the last
+two pages — enough to cover about 100 new stars between runs.
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/github-star-notifier)
+   — click the **Remix** button in the top right corner.
+2. In `config.ts`, set `REPO` to your repo, e.g. `"yourname/yourrepo"`.
+
+The first run seeds the list of current stargazers without emailing; after
+that, each new star triggers an email to your Val Town account address.
+
+## Notes
+
+- Notifications go to your Val Town account email — that's where
+  [std/email](/reference/std/email/) delivers by default.
+- The keyless GitHub API allows 60 requests per hour per IP, and this val
+  uses up to 3 per run — the hourly schedule keeps usage low. Don't crank
+  the schedule much faster without adding a token.
+- The repo must be public; the keyless API can't see private repos.
+
+## Next steps
+
+- [Cron reference](/vals/cron/) — schedule types and limits
+- [Receiving a GitHub webhook](/guides/github/receiving-a-github-webhook/) —
+  push-based GitHub events instead of polling
+- [Paginating GitHub stars](/guides/github/github-users-stars-pagination/) —
+  walking the full stargazer list

--- a/src/content/docs/guides/host-stripe-webhook-receiver.mdx
+++ b/src/content/docs/guides/host-stripe-webhook-receiver.mdx
@@ -1,0 +1,65 @@
+---
+title: Host a Stripe webhook receiver
+description: Remix an HTTP val that verifies Stripe webhook signatures and
+  stores every event in SQLite — no server to deploy
+# cspell:ignore whsec
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+A Stripe webhook receiver is just an HTTPS endpoint, but it has to be
+deployed somewhere public before Stripe will deliver to it — which makes a
+plain [HTTP val](/vals/http/) a natural home for one. This template is a
+ready-made receiver: it verifies the `Stripe-Signature` header against your
+webhook signing secret, stores each event in the val's
+[SQLite database](/reference/std/sqlite/), and returns 200 immediately.
+
+If you're starting from the payments side — payment links, Stripe Checkout,
+and what a fulfillment webhook is for — read the
+[Stripe webhooks guide](/guides/stripe/) first. This page is just the
+hosted-receiver part.
+
+## The receiver
+
+<Val url="https://www.val.town/embed/x/templates/stripe-webhook-receiver/main.ts" />
+
+The `saveEvent` helper in `db.ts` creates a `stripe_events` table (id, type,
+created, full event JSON) and ignores duplicate deliveries of the same event
+id, so Stripe's at-least-once delivery doesn't create duplicate rows.
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/stripe-webhook-receiver)
+   — click the **Remix** button in the top right corner.
+2. In the [Stripe dashboard](https://dashboard.stripe.com/webhooks/create),
+   add a webhook endpoint pointing at your val's HTTP URL (shown on the HTTP
+   trigger of `main.ts`).
+3. Copy that endpoint's signing secret (it starts with `whsec_`) and add it
+   to your val's [environment variables](/reference/environment-variables/)
+   as `STRIPE_WEBHOOK_SECRET`.
+
+To test it, configure your endpoint in Stripe test mode and run
+`stripe trigger payment_intent.succeeded` with the
+[Stripe CLI](https://docs.stripe.com/stripe-cli). Expect `{"received":true}`
+and a new row in `stripe_events` — the val's README also shows how to forge
+a correctly signed test event with curl. Requests with a missing or bad
+signature get a 400.
+
+## Notes
+
+- Signature verification only needs the webhook secret — no Stripe API key
+  is required to receive events.
+- Each remix gets its own private SQLite database, so your event log stays
+  with your copy. Browse it in the val's SQLite tab.
+- The receiver stores events and returns immediately. Do fulfillment work
+  (sending emails, updating your database) by querying `stripe_events`, or
+  add it to the handler after `saveEvent`.
+
+## Next steps
+
+- [Stripe webhooks guide](/guides/stripe/) — payment links, Stripe Checkout,
+  and fulfillment
+- [Creating a webhook](/guides/creating-a-webhook/) — webhooks on Val Town in
+  general
+- [SQLite reference](/reference/std/sqlite/) — querying your stored events

--- a/src/content/docs/guides/put-a-form-online.mdx
+++ b/src/content/docs/guides/put-a-form-online.mdx
@@ -1,0 +1,48 @@
+---
+title: Put a form online and save submissions
+description: Remix an HTTP val that serves a contact form, saves every
+  submission to SQLite, and lists what people sent — no external services
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+The easiest way to put a form online is to remix a val that already is one.
+This template serves a contact form (name, email, message) at `/`, saves
+every submission to the val's own [SQLite database](/reference/std/sqlite/),
+and lists everything received at `/submissions`. No form-builder service, no
+API keys, no environment variables.
+
+## The form server
+
+<Val url="https://www.val.town/embed/x/templates/form-to-sqlite/main.tsx" />
+
+`db.ts` creates the `submissions` table and holds the two queries, and the
+`components/` files render the pages with Hono JSX. The form is a plain HTML
+POST — there's no client-side JavaScript at all.
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/form-to-sqlite)
+   — click the **Remix** button in the top right corner.
+2. Open the HTTP endpoint of `main.tsx` (shown on its HTTP trigger) — that's
+   your live form. Share the URL.
+3. Visit `/submissions` on the same URL to see what people sent.
+
+## Notes
+
+- Each remix gets its own private SQLite database, so your submissions stay
+  with your copy. You can also browse them in the val's SQLite tab.
+- `/submissions` is public by default. If your form collects anything
+  sensitive, protect that route — the [auth guide](/guides/auth/) shows how
+  to add basic or password auth — before sharing the form URL.
+- To change the fields, edit the form in `components/FormPage.tsx`, the
+  validation in `main.tsx`, and the table in `db.ts`.
+
+## Next steps
+
+- [SQLite reference](/reference/std/sqlite/) — querying and migrating your
+  submissions table
+- [Save HTML form data](/guides/save-html-form-data/) — the same pattern
+  built up from scratch
+- [HTTP val reference](/vals/http/) — routing, JSX, and custom domains

--- a/src/content/docs/guides/rss-daily-email-digest.mdx
+++ b/src/content/docs/guides/rss-daily-email-digest.mdx
@@ -1,0 +1,51 @@
+---
+title: Get a daily email digest of an RSS feed
+description: Remix a cron val that checks an RSS feed once a day and emails
+  you only the items published since its last run
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+Instead of signing up for a feed-reader-to-email service, you can run the
+whole thing as one [cron-triggered val](/vals/cron/): fetch the feed daily,
+diff against the last-run timestamp stored in
+[blob storage](/reference/std/blob/), and email yourself the new items with
+[std/email](/reference/std/email/). If nothing new was published, no email
+is sent.
+
+## The digest cron
+
+<Val url="https://www.val.town/embed/x/templates/rss-to-email-digest/main.tsx" />
+
+The template splits the rest of the work into small files: `rss.ts` fetches
+and parses the feed (any RSS or Atom feed works), `digest.tsx` renders the
+email HTML, and `email.ts` wraps `std/email` with a small retry since sends
+can fail transiently.
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/rss-to-email-digest)
+   — click the **Remix** button in the top right corner.
+2. In `main.tsx`, set `FEED_URL` to the feed you want.
+3. Optional: click **Run** on `main.tsx` to test it immediately. On the
+   first run it looks back 24 hours.
+
+No API keys or environment variables are needed.
+
+## Notes
+
+- The digest goes to your Val Town account email — that's where
+  [std/email](/reference/std/email/) delivers by default.
+- The schedule is `0 13 * * *` — daily at 13:00 UTC (9am Eastern). Cron
+  expressions always run in UTC, so adjust the schedule on `main.tsx` for
+  your timezone.
+- The last-run timestamp in blob storage is what guarantees you never get
+  the same item twice, even if you change the schedule.
+
+## Next steps
+
+- [Cron reference](/vals/cron/) — schedule types and the `Interval` handler
+- [RSS guide](/guides/rss/) — parsing and generating feeds on Val Town
+- [Scrape a website daily and email yourself the results](/guides/scrape-website-daily-email/)
+  — the same cron-plus-email recipe for pages without a feed

--- a/src/content/docs/guides/website-down-email-alert.mdx
+++ b/src/content/docs/guides/website-down-email-alert.mdx
@@ -1,0 +1,52 @@
+---
+title: Get an email alert when your website goes down
+description: Remix a cron val that checks your website every five minutes
+  and emails you once when it goes down and once when it recovers
+lastUpdated: 2026-06-10
+---
+
+import Val from "@components/Val.astro";
+
+The usual answer is to sign up for an uptime monitoring service. On Val Town
+it's one [cron-triggered val](/vals/cron/): fetch your URL on a schedule,
+remember the last known status in [blob storage](/reference/std/blob/), and
+send yourself an email with [std/email](/reference/std/email/) only when the
+status changes — one email when the site goes down, one when it recovers.
+
+## The monitor
+
+<Val url="https://www.val.town/embed/x/templates/uptime-monitor-email-alert/monitor.ts" />
+
+Because the last status is stored in blob storage, you never get repeat
+alerts while the site stays down. The first run only records a baseline, so
+remixing it never sends a surprise email.
+
+## Set it up
+
+1. [Remix this template](https://www.val.town/x/templates/uptime-monitor-email-alert)
+   — click the **Remix** button in the top right corner.
+2. In `monitor.ts`, change `URL_TO_MONITOR` to your website's URL.
+
+That's it: no API keys, no environment variables, no signup for a monitoring
+service. To test it, point `URL_TO_MONITOR` at a URL that 404s and click
+**Run** on `monitor.ts` twice — the first run records the baseline, the
+second one emails you.
+
+## Notes
+
+- Alerts go to your Val Town account email — that's where
+  [std/email](/reference/std/email/) delivers by default.
+- The template checks every five minutes (`*/5 * * * *`). On the free plan
+  crons run at most once every 15 minutes, so change the schedule to
+  `*/15 * * * *` (or upgrade to [Pro](https://www.val.town/pricing) for up to
+  once a minute).
+- A response is counted as up when `res.ok` is true (status 200–299), and as
+  down on any other status or a network error.
+
+## Next steps
+
+- [Cron reference](/vals/cron/) — schedule types and limits
+- [std/email reference](/reference/std/email/) — subject, attachments, and
+  sending limits
+- [Website uptime tracker](/guides/website-uptime-tracker/) — community
+  variations on the same idea


### PR DESCRIPTION
Six task-phrased guide pages, one per template in the `templates` org. Each answers a search query from the SEO audit, embeds the template's primary file (inlined at build time into the HTML, `.md` routes, and `llms-full.txt`), and links to remix the template.

- `guides/website-down-email-alert` — "email alert when my website goes down" (templates/uptime-monitor-email-alert)
- `guides/host-stripe-webhook-receiver` — "host a Stripe webhook receiver" (templates/stripe-webhook-receiver; complements the existing Stripe guide and cross-links it)
- `guides/rss-daily-email-digest` — "daily email digest of an RSS feed" (templates/rss-to-email-digest)
- `guides/github-star-notifications` — "get notified when someone stars my GitHub repo" (templates/github-star-notifier)
- `guides/put-a-form-online` — "put a form online and save submissions" (templates/form-to-sqlite)
- `guides/cache-rate-limited-api` — "cache a rate-limited API behind your own endpoint" (templates/cached-api-proxy)

Build, biome lint, and cspell pass locally; all six pages appear in `dist/llms-full.txt` with their template source inlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->