### PR TITLE
Point moved val embeds at the examples org

### DIFF
--- a/src/content/docs/guides/Slack/agent.mdx
+++ b/src/content/docs/guides/Slack/agent.mdx
@@ -23,7 +23,7 @@ In [5 or 10 minutes](https://screen.studio/share/3NFNHgtF), you'll have an agent
 1. Under App Home > Show Tabs > Chat Tab, check "Allow users to send Slash
    commands and messages from the chat tab"
 1. Under OAuth & Permissions > OAuth Tokens, install the app to your workspace
-1. Remix this [slack agent](https://www.val.town/x/petermillspaugh/duck) template val
+1. Remix this [slack agent](https://www.val.town/x/examples/duck) template val
 1. Add [environment variables](https://docs.val.town/reference/environment-variables/)
    in your val sidebar:
    1. `SLACK_BOT_TOKEN` in your Slack app: OAuth & Permissions > OAuth Tokens >

--- a/src/content/docs/guides/Slack/agent.mdx
+++ b/src/content/docs/guides/Slack/agent.mdx
@@ -70,7 +70,7 @@ At this point, you should already be able to chat with your agent in Slack via @
 
 The `events.ts` file exposes an API from the val's HTTP URL using Hono. The `POST /events` route is where Slack webhooks come in and get routed based on their event type (@mention, thread started, or generic message).
 
-<Val url="https://www.val.town/embed/x/templates/duck/events.ts" />
+<Val url="https://www.val.town/embed/x/examples/duck/events.ts" />
 
 The `POST` route verifies that webhooks are indeed coming from Slack then handles three types of events in its core try-catch loop:
 
@@ -86,7 +86,7 @@ Slack [expects a response within 3 seconds](https://docs.slack.dev/apis/events-a
 
 When you mention your bot in a channel or channel thread, the `app_mention` event is triggered, which we handle in `handle-app-mention.ts`:
 
-<Val url="https://www.val.town/embed/x/templates/duck/lib/handle-app-mention.ts" />
+<Val url="https://www.val.town/embed/x/examples/duck/lib/handle-app-mention.ts" />
 
 1. Checks if the message is from a bot to avoid infinite response loops
 2. Creates a status updater to show the bot is "thinking"
@@ -97,7 +97,7 @@ When you mention your bot in a channel or channel thread, the `app_mention` even
 
 When you start a thread with your assistant in its dedicated Slack app chat interface, the `assistant_thread_started` event is triggered, which we handle in `handle-thread-started.ts`:
 
-<Val url="https://www.val.town/embed/x/templates/duck/lib/handle-thread-started.ts" />
+<Val url="https://www.val.town/embed/x/examples/duck/lib/handle-thread-started.ts" />
 
 1. Your agent sends a welcome message to the thread
 2. Sets up suggested prompts to help users get started
@@ -108,7 +108,7 @@ You should tailor these, of course, based on your needs.
 
 For direct messages to your bot in its dedicated Slack app chat interface, the `message` event is triggered, which we handle in `handle-message.ts`:
 
-<Val url="https://www.val.town/embed/x/templates/duck/lib/handle-message.ts" />
+<Val url="https://www.val.town/embed/x/examples/duck/lib/handle-message.ts" />
 
 1. Ignore messages from the agent (bot) itself
 1. Update the status ahead of the LLM call
@@ -120,7 +120,7 @@ For direct messages to your bot in its dedicated Slack app chat interface, the `
 
 The core AI parts of your agent live in `generate-response.ts`:
 
-<Val url="https://www.val.town/embed/x/templates/duck/lib/generate-response.ts" />
+<Val url="https://www.val.town/embed/x/examples/duck/lib/generate-response.ts" />
 
 1. Loads your system prompt
 1. Uses the Vercel AI SDK's `generateText` function with Anthropic's `claude-sonnet-4.6` model

--- a/src/content/docs/guides/cache-rate-limited-api.mdx
+++ b/src/content/docs/guides/cache-rate-limited-api.mdx
@@ -35,16 +35,16 @@ gets.
 The cron half fetches the upstream and writes `{ fetchedAt, data }` to a
 blob:
 
-<Val url="https://www.val.town/embed/x/templates/cached-api-proxy/refresh.ts" />
+<Val url="https://www.val.town/embed/x/examples/cached-api-proxy/refresh.ts" />
 
 The HTTP half serves the cache with an `X-Cache-Age` header (and a 503 if
 the cache is empty):
 
-<Val url="https://www.val.town/embed/x/templates/cached-api-proxy/main.ts" />
+<Val url="https://www.val.town/embed/x/examples/cached-api-proxy/main.ts" />
 
 ## Set it up
 
-1. [Remix this template](https://www.val.town/x/templates/cached-api-proxy)
+1. [Remix this template](https://www.val.town/x/examples/cached-api-proxy)
    — click the **Remix** button in the top right corner.
 2. Get a free API key at [openweathermap.org/api](https://openweathermap.org/api).
 3. Add it to your val's

--- a/src/content/docs/guides/qr-code.mdx
+++ b/src/content/docs/guides/qr-code.mdx
@@ -13,4 +13,4 @@ Visit
 [https://neverstew-generateQR.web.val.run?url=https://neverstew.com](https://neverstew-generateqr.web.val.run/?url=https://neverstew.com)
 and replace the url query parameter with your link.
 
-<Val url="https://www.val.town/embed/x/templates/generateQR/main.tsx" />
+<Val url="https://www.val.town/embed/x/examples/generateQR/main.tsx" />

--- a/src/content/docs/guides/sqlite-wasm.mdx
+++ b/src/content/docs/guides/sqlite-wasm.mdx
@@ -25,7 +25,7 @@ You can create, insert, query, and persist a whole SQLite database in Val Town v
 
 ## Example Usage
 
-<Val url="https://www.val.town/embed/x/templates/exampleSQLiteAdd/main.ts" />
+<Val url="https://www.val.town/embed/x/examples/exampleSQLiteAdd/main.ts" />
 
 ## Database in Val Town
 

--- a/src/content/docs/guides/supabase.mdx
+++ b/src/content/docs/guides/supabase.mdx
@@ -11,7 +11,7 @@ Handling Supabase webhooks in Val Town allows you to run arbitrary logic wheneve
 
 Create a new val using the webhook template, or remix this example val:
 
-<Val url="https://www.val.town/embed/x/templates/supabaseWebhook/main.ts" />
+<Val url="https://www.val.town/embed/x/examples/supabaseWebhook/main.ts" />
 
 ## Configure webhook(s) in Supabase
 


### PR DESCRIPTION
The five docs-example vals (supabaseWebhook, duck, exampleSQLiteAdd, generateQR, cached-api-proxy) moved from the templates org to the new examples org; transfers keep everything working except val.town/esm.town URLs, so the 11 embed/link references needed retargeting. Build verified: all fetches resolve from the new org, llms-full.txt carries the inlined code. The five guide templates staying in the templates org are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->