### PR TITLE
Fix dead townie demo link (renamed handle)

### DIFF
--- a/src/content/docs/guides/Slack/agent.mdx
+++ b/src/content/docs/guides/Slack/agent.mdx
@@ -129,4 +129,4 @@ The core AI parts of your agent live in `generate-response.ts`:
 
 ## Make it your own
 
-We've set up this val template and guide with web search as its only tool, but the goal is for you to make it your own! You could connect to the Val Town MCP server, like we've done with this demo [townie](https://www.val.town/x/petermillspaugh/townie) val. Or you could create a customer support bot, like this [template for Pylon](https://www.val.town/x/templates/pylon-support-bot). Feel free to reach out in our [Discord server](https://discord.val.town/) for help or to share what you've made.
+We've set up this val template and guide with web search as its only tool, but the goal is for you to make it your own! You could connect to the Val Town MCP server, like we've done with this demo [townie](https://www.val.town/x/pmillspaugh/townie) val. Or you could create a customer support bot, like this [template for Pylon](https://www.val.town/x/templates/pylon-support-bot). Feel free to reach out in our [Discord server](https://discord.val.town/) for help or to share what you've made.


### PR DESCRIPTION
The Slack agent guide's townie demo link still used the petermillspaugh handle, which renamed to pmillspaugh — the old URL 404s, the new one resolves. One-line fix, surfaced while verifying #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->