### PR TITLE
Add two task-phrased guides from the SEO audit

### DIFF
--- a/src/content/docs/guides/deploy-an-api-endpoint.mdx
+++ b/src/content/docs/guides/deploy-an-api-endpoint.mdx
@@ -1,0 +1,75 @@
+---
+title: Deploy an API endpoint in under a minute
+description: Write a fetch handler in an HTTP val and get a live HTTPS URL
+  the moment you save — no Dockerfile, no deploy pipeline
+# cspell:ignore yourname
+lastUpdated: 2026-06-11
+---
+
+An [HTTP val](/vals/http/) is a fetch handler with a public URL: you write a
+function that takes a web-standard
+[Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
+returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
+and it's live at its own URL as soon as you save. There's no Dockerfile, no
+deploy pipeline, and nothing to provision.
+
+## The endpoint
+
+This is a complete JSON API with one parameterized route, using
+[Hono](https://hono.dev/) — the router we typically recommend:
+
+```ts title="api.ts" val
+import { Hono } from "npm:hono";
+
+const app = new Hono();
+
+app.get("/greet/:name", (c) =>
+  c.json({ message: `Hello, ${c.req.param("name")}!` })
+);
+
+export default app.fetch;
+```
+
+If you don't need routes, skip Hono entirely and export a plain handler:
+
+```ts title="Plain handler"
+export default async function (req: Request): Promise<Response> {
+  return Response.json({ ok: true });
+}
+```
+
+## Set it up
+
+1. [Create a val](https://www.val.town/) and add a file.
+2. Click the `+` button in the top right of the editor and select `HTTP`.
+3. Paste in the code above and save. The HTTP trigger shows your endpoint
+   URL — something like `yourname-api.web.val.run`.
+
+Then hit it from your terminal:
+
+```sh
+curl https://yourname-api.web.val.run/greet/world
+```
+
+```json
+{ "message": "Hello, world!" }
+```
+
+Requests to any path on that subdomain are routed to your file, so the
+`/greet/:name` route just works.
+
+## What you get for free
+
+- **HTTPS** — the endpoint URL is HTTPS from the start, no certificates to
+  manage.
+- **Logs and traces** — every request shows up in the val's logs, including
+  anything you `console.log`.
+- **Instant redeploys** — every save deploys and is automatically versioned,
+  and rollbacks are instantaneous.
+
+## Next steps
+
+- [HTTP reference](/vals/http/) — basic examples, routing, JSX, and custom
+  domains
+- [Put a form online and save submissions](/guides/put-a-form-online/) — a
+  complete HTTP val that serves pages and stores data

--- a/src/content/docs/guides/run-typescript-on-a-schedule.mdx
+++ b/src/content/docs/guides/run-typescript-on-a-schedule.mdx
@@ -1,0 +1,88 @@
+---
+title: Run TypeScript on a schedule
+description: Create a cron val, paste your TypeScript, and pick a schedule —
+  no runtime to host, no process manager, no crontab
+# cspell:ignore crongpt githubstatus
+lastUpdated: 2026-06-11
+---
+
+The usual way to run a scheduled TypeScript script is to keep a machine on:
+a script run with bun or tsx, a `node-schedule` timer or a crontab entry,
+and a process manager to restart it when it dies. On Val Town the scheduler
+is part of the platform — you write the function, set the schedule, and
+there's no runtime to host and no process to keep alive.
+
+Here's the 30-second version:
+
+1. [Create a val](https://www.val.town/) and add a file.
+2. Click the `+` button in the top right of the editor and select `CRON`.
+3. Paste in your TypeScript and click **Run** to test it.
+4. Click the Cron trigger and set the schedule — a simple interval like
+   "once an hour", or a cron expression.
+
+## The handler
+
+A cron-triggered file exports a function that receives an `Interval` object:
+
+```ts title="Handler"
+export default async function (interval: Interval) {
+  console.log("Cron val ran!");
+}
+```
+
+The `Interval` type has this shape:
+
+```ts
+interface Interval {
+  lastRunAt: Date | undefined;
+}
+```
+
+Anything you return is ignored — output goes to the val's logs, or wherever
+your code sends it.
+
+## A complete example
+
+This job fetches GitHub's status API on every run and logs the current
+status, so the val's logs become a history of outages:
+
+```ts title="statusLogger.ts" val
+export default async function (interval: Interval) {
+  const res = await fetch("https://www.githubstatus.com/api/v2/status.json");
+  const { status } = await res.json();
+  console.log(`GitHub status: ${status.description}`);
+}
+```
+
+Paste it into a cron-triggered file, click **Run**, and check the logs. Any
+TypeScript works here — `npm:` imports included — so the body of your
+existing script usually drops in unchanged.
+
+## Picking up where the last run left off
+
+`interval.lastRunAt` is the time of the previous run (`undefined` on the
+first one), which is all you need for incremental jobs — polling a feed,
+processing new records, diffing since last time:
+
+```ts title="Incremental work"
+export default async function (interval: Interval) {
+  const since = interval.lastRunAt ?? new Date(0);
+  // fetch items and keep only the ones newer than `since`
+}
+```
+
+## Scheduling notes
+
+- Cron expressions are evaluated in UTC, so adjust for your timezone —
+  [crongpt.com](https://crongpt.com) handles the conversion for you.
+- On the free plan, crons can run up to once every 15 minutes;
+  [Pro](https://www.val.town/pricing) allows up to once a minute.
+
+## Next steps
+
+- [Cron reference](/vals/cron/) — schedule types, the `Interval` handler,
+  and limits
+- [Scrape a website daily and email yourself the results](/guides/scrape-website-daily-email/)
+  — a complete worked example of a scheduled job
+- [Your first scheduled cron](/guides/first-cron/) — a step-by-step
+  walkthrough building a weather notifier


### PR DESCRIPTION
- `guides/run-typescript-on-a-schedule` — targets "fastest way to run a scheduled typescript script"; generic cron-val page (handler signature, fetch-and-log example, `lastRunAt`, UTC + 15-minute free-plan floor), distinct from the scrape-daily guide.
- `guides/deploy-an-api-endpoint` — targets "deploy tiny api endpoint fast"; fetch handler → live URL on save, minimal Hono JSON API, curl test, what you get for free (HTTPS, logs, instant redeploys). The homepage's sub-100ms deploy claim isn't on val.town today, so it's omitted.

Optional, for Steve to decide: the audit also suggested retitling the cron reference H1 (`/vals/cron/`, currently "Cron") to something task-phrased like "Run code on a schedule (Cron)". Not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->