### PR TITLE
Fix codex mcp login command syntax

### DIFF
--- a/src/content/docs/guides/Prompting/openai-codex.mdx
+++ b/src/content/docs/guides/Prompting/openai-codex.mdx
@@ -32,7 +32,7 @@ codex mcp add val-town --url https://api.val.town/v3/mcp
 3. Login to the MCP server:
 
 ```
-codex mcp login val_town
+codex mcp login val-town
 ```
 
 ## CLI


### PR DESCRIPTION
`val_town` appears to have been a typo or perhaps a relic

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->