### PR TITLE
Fix Tables and Smart Quotes Silently Dropping From Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,13 @@ import starlightLinksValidator from "starlight-links-validator";
 // https://astro.build/config
 export default defineConfig({
   site: "https://docs.val.town/",
+  // Astro 6.4 leaves markdown.gfm/smartypants undefined unless set explicitly,
+  // and @astrojs/mdx 5.x reads them as falsy and drops remark-gfm — so tables
+  // and smart quotes silently stop rendering in .mdx pages. Set them on.
+  markdown: {
+    gfm: true,
+    smartypants: true,
+  },
   redirects: {
     "/api/vals/": "/openapi.html#tag/vals",
     "/api/eval/": "/openapi.html#tag/vals",


### PR DESCRIPTION
## The bug

Markdown tables on `.mdx` pages render as literal pipe text (`| Approach | Best for |` / `|---|`) instead of HTML tables, and smart/curly quotes are gone. This is live on production right now — see [docs.val.town/guides/auth/](https://docs.val.town/guides/auth/), where the "Which approach" table is raw pipes.

## Root cause

Astro 6.4 changed `markdown.gfm` and `markdown.smartypants` to be left `undefined` in the resolved config unless set explicitly (the default is supplied internally by Astro core). Astro core still renders plain `.md` with GFM, but `@astrojs/mdx` 5.x reads `config.markdown.gfm` directly and gates the plugin with `if (mdxOptions.gfm)` — `undefined` is falsy, so `remark-gfm` and `remark-smartypants` are silently dropped for every `.mdx` page.

The lockfile has pinned `astro@6.4.4` since the `Update astro monorepo` commit on 2026-06-03, which is when production broke. Plain `.md` pages were never affected (only `.mdx`).

## Why CI stayed green and local builds looked fine

- Local `node_modules` here is stale (astro 5, pre-lockfile-bump), so local `npm run build` still produced tables.
- CI builds with the broken deps, but nothing asserts table HTML.
- Cloudflare Pages installs fresh from the lockfile → astro 6.4.4 + mdx 5.x → broken.

## The fix

Set `markdown: { gfm: true, smartypants: true }` explicitly so the options are defined and mdx re-enables the plugins.

Verified with a fresh `npm ci` (the exact committed lockfile, node 24, matching the Cloudflare build): the `/guides/auth/` table goes from 0 → 1 rendered `<table>`, the literal `|---|` rows disappear, and smart quotes return (0 → 5 on that page). Build completes, all pages built.

The long-term fix is upgrading Starlight to ≥0.40 (which pulls mdx 6, where this is handled), but that's a breaking change to the `autogenerate` sidebar config — out of scope for this one-line-behavior fix. Astro 6.4 logs a deprecation note for these options; they still work and are the minimal fix today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->