### PR TITLE
Add page on custom user skills

### DIFF
--- a/src/content/docs/guides/Prompting/claude-code.mdx
+++ b/src/content/docs/guides/Prompting/claude-code.mdx
@@ -2,7 +2,7 @@
 title: Claude Code
 description: Bring Val Town to Claude Code with the Val Town MCP server
 sidebar:
-  order: 5
+  order: 6
 ---
 
 The easiest way to work with Val Town in Claude Code is to install the `valtown` plugin from Claude Code's official marketplace:

--- a/src/content/docs/guides/Prompting/cli.mdx
+++ b/src/content/docs/guides/Prompting/cli.mdx
@@ -2,7 +2,7 @@
 title: vt CLI
 description: A guide to using the Val Town CLI with your favorite AI tool
 sidebar:
-  order: 4
+  order: 5
 ---
 
 import { Steps, CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/src/content/docs/guides/Prompting/cursor.mdx
+++ b/src/content/docs/guides/Prompting/cursor.mdx
@@ -2,7 +2,7 @@
 title: Cursor
 description: Bring Val Town to Cursor with the vt CLI
 sidebar:
-  order: 7
+  order: 8
 ---
 
 Install the [Val Town plugin](/guides/prompting/plugin) for Cursor:

--- a/src/content/docs/guides/Prompting/index.mdx
+++ b/src/content/docs/guides/Prompting/index.mdx
@@ -9,7 +9,7 @@ import Val from "@components/Val.astro";
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 :::tip
-We recommend using [Townie](/guides/prompting/townie) or installing the [Val Town plugin](/guides/prompting/plugin), which bundles the MCP server and platform skills and works with Claude Code, Codex, and Cursor.
+We recommend using [Townie](/guides/prompting/townie) or installing the [Val Town plugin](/guides/prompting/plugin), which bundles the MCP server with platform skills and works with Claude Code, Codex, and Cursor.
 :::
 
 <CardGrid>
@@ -32,6 +32,11 @@ We recommend using [Townie](/guides/prompting/townie) or installing the [Val Tow
     title="vt CLI"
     description="CLI for Val Town"
     href="/guides/prompting/cli"
+  />
+  <LinkCard
+    title="Custom skills"
+    description="Custom skills for your LLM"
+    href="/guides/prompting/skills"
   />
 </CardGrid>
 

--- a/src/content/docs/guides/Prompting/index.mdx
+++ b/src/content/docs/guides/Prompting/index.mdx
@@ -2,7 +2,7 @@
 title: Overview
 description: A guide to using AI inside and outside Val Town
 sidebar:
-  order: 1
+  order: 0
 ---
 
 import Val from "@components/Val.astro";

--- a/src/content/docs/guides/Prompting/openai-codex.mdx
+++ b/src/content/docs/guides/Prompting/openai-codex.mdx
@@ -2,7 +2,7 @@
 title: Codex
 description: Bring Val Town to OpenAI Codex with the vt CLI or MCP
 sidebar:
-  order: 6
+  order: 7
 ---
 
 The easiest way to work with Val Town in Codex is to install the Val Town plugin:

--- a/src/content/docs/guides/Prompting/skills.mdx
+++ b/src/content/docs/guides/Prompting/skills.mdx
@@ -45,11 +45,13 @@ speed and productivity...
 - `description`: helps the agent decide when the skill is relevant
 - `triggers`: (optional) is a list of keywords to tip off the agent
 
+The `description` field enables skill discovery, i.e. tells your agent when to use it. The more specific the better, including key terms that should trigger use (which you can also enumerate in `triggers`). Always write in third person. [Read more tips on Claude's docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#writing-effective-descriptions).
+
 Skills without frontmatter will be silently skipped, so Townie/MCP will not be able to access them.
 
 ## Remixing skills
 
-To adopt another user's skills, simply remix the val.
+To adopt another user's skills, simply remix the val and customize the `SKILL.md` file. It is trivially easy to remix a skill into your account, and customizing skills is powerful because you can personalize them based on your specific knowledge and preferences.
 
 :::tip
 Liking your new skill? We'd like to know! Share it in our [discord](https://discord.val.town) #showcase channel.

--- a/src/content/docs/guides/Prompting/skills.mdx
+++ b/src/content/docs/guides/Prompting/skills.mdx
@@ -2,7 +2,7 @@
 title: Skills
 description: Create custom skills for your agent and Townie
 sidebar:
-  order: 1
+  order: 4
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/guides/Prompting/skills.mdx
+++ b/src/content/docs/guides/Prompting/skills.mdx
@@ -1,0 +1,56 @@
+---
+title: Skills
+description: Create custom skills for your agent and Townie
+sidebar:
+  order: 1
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+The Val Town [plugin](/guides/prompting/plugin) ships with platform skills for things like using OAuth, SQLite, and blob storage. You can create your own custom skills that [Townie](/guides/prompting/townie) and our [MCP server](/guides/prompting/mcp) will automatically pick up on and use in the appropriate scenario.
+
+## Creating a skill
+
+In any val:
+
+<Steps>
+
+1. Create a `skills/` directory
+
+2. Create a `<name>/` subdir
+
+3. Create a `SKILL.md` file with `name` and `description` metadata, plus the skill itself
+
+</Steps>
+
+For example, you can expose a [Slow Mode](https://blog.val.town/slow-mode) skill by remixing this [slow-mode](https://www.val.town/x/pmillspaugh/slow-mode) val, which contains `skills/slow-mode/SKILL.md` with the following markdown:
+
+```md
+---
+name: slow-mode
+description: Use when the user wants to work in "slow mode" or mentions wanting to learn how something works while building
+triggers:
+  - slow mode
+---
+
+# Slow Mode
+
+You are in Slow Mode, which emphasizes human learning and decision making, not
+speed and productivity...
+```
+
+### Frontmatter
+
+- `name`: typically matches the subdir name slug
+- `description`: helps the agent decide when the skill is relevant
+- `triggers`: (optional) is a list of keywords to tip off the agent
+
+Skills without frontmatter will be silently skipped, so Townie/MCP will not be able to access them.
+
+## Remixing skills
+
+To adopt another user's skills, simply remix the val.
+
+:::tip
+Liking your new skill? We'd like to know! Share it in our [discord](https://discord.val.town) #showcase channel.
+:::


### PR DESCRIPTION
As follow-up we could add more example skills, or share a collection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->