### PR TITLE
Fix Stripe webhook URL example

### DIFF
--- a/src/content/docs/guides/creating-a-webhook.mdx
+++ b/src/content/docs/guides/creating-a-webhook.mdx
@@ -12,7 +12,7 @@ Discord, and Stripe – let you configure webhooks so that you can get programma
 When the event happens, they will send an HTTP request to a URL you specify.
 
 For example, we registered
-[this val](https://www.val.town/x/stevekrouse/newStripeEvent) to receive webhooks from Stripe
+[this val](https://www.val.town/x/stevekrouse/newStripeSubscriber) to receive webhooks from Stripe
 when we get a new subscriber to Val Town Pro. It sends new subscribers a thank you email and notifies our team in our internal Discord channel.
 
 ## Creating a webhook


### PR DESCRIPTION
The linked val was moved; this updates the link to the new val.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/val-town-docs/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->